### PR TITLE
Add full Timestamp support.

### DIFF
--- a/txmongo/_pymongo/bson.py
+++ b/txmongo/_pymongo/bson.py
@@ -27,6 +27,7 @@ from txmongo._pymongo.binary import Binary
 from txmongo._pymongo.code import Code
 from txmongo._pymongo.objectid import ObjectId
 from txmongo._pymongo.son import SON
+from txmongo._pymongo.timestamp import Timestamp
 from txmongo._pymongo.errors import InvalidBSON, InvalidDocument
 from txmongo._pymongo.errors import InvalidName, InvalidStringData
 
@@ -325,9 +326,9 @@ def _get_ref(data):
 
 
 def _get_timestamp(data):
-    (timestamp, data) = _get_int(data)
     (inc, data) = _get_int(data)
-    return ((timestamp, inc), data)
+    (timestamp, data) = _get_int(data)
+    return (Timestamp(timestamp, inc), data)
 
 
 def _get_long(data):
@@ -466,6 +467,10 @@ def _element_to_bson(key, value, check_keys):
         return "\x0B" + name + _make_c_string(pattern, True) + _make_c_string(flags)
     if isinstance(value, DBRef):
         return _element_to_bson(key, value.as_doc(), False)
+    if isinstance(value, Timestamp):
+        inc = struct.pack("<i", value.inc)
+        timestamp = struct.pack("<i", value.time)
+        return "\x11" + name + inc + timestamp
 
     raise InvalidDocument("cannot convert value of type %s to bson" %
                           type(value))

--- a/txmongo/_pymongo/timestamp.py
+++ b/txmongo/_pymongo/timestamp.py
@@ -1,0 +1,96 @@
+# Copyright 2010 10gen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for representing MongoDB internal Timestamps.
+"""
+
+import calendar
+import datetime
+
+from tz_util import utc
+
+
+class Timestamp(object):
+    """MongoDB internal timestamps used in the opLog.
+    """
+
+    def __init__(self, time, inc):
+        """Create a new :class:`Timestamp`.
+
+        This class is only for use with the MongoDB opLog. If you need
+        to store a regular timestamp, please use a
+        :class:`~datetime.datetime`.
+
+        Raises :class:`TypeError` if `time` is not an instance of
+        :class: `int` or :class:`~datetime.datetime`, or `inc` is not
+        an instance of :class:`int`. Raises :class:`ValueError` if
+        `time` or `inc` is not in [0, 2**32).
+
+        :Parameters:
+          - `time`: time in seconds since epoch UTC, or a naive UTC
+            :class:`~datetime.datetime`, or an aware
+            :class:`~datetime.datetime`
+          - `inc`: the incrementing counter
+
+        .. versionchanged:: 1.7
+           `time` can now be a :class:`~datetime.datetime` instance.
+        """
+        if isinstance(time, datetime.datetime):
+            if time.utcoffset() is not None:
+                time = time - time.utcoffset()
+            time = int(calendar.timegm(time.timetuple()))
+        if not isinstance(time, (int, long)):
+            raise TypeError("time must be an instance of int")
+        if not isinstance(inc, (int, long)):
+            raise TypeError("inc must be an instance of int")
+        if not 0 <= time < 2 ** 32:
+            raise ValueError("time must be contained in [0, 2**32)")
+        if not 0 <= inc < 2 ** 32:
+            raise ValueError("inc must be contained in [0, 2**32)")
+
+        self.__time = time
+        self.__inc = inc
+
+    @property
+    def time(self):
+        """Get the time portion of this :class:`Timestamp`.
+        """
+        return self.__time
+
+    @property
+    def inc(self):
+        """Get the inc portion of this :class:`Timestamp`.
+        """
+        return self.__inc
+
+    def __eq__(self, other):
+        if isinstance(other, Timestamp):
+            return (self.__time == other.time and self.__inc == other.inc)
+        else:
+            return NotImplemented
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __repr__(self):
+        return "Timestamp(%s, %s)" % (self.__time, self.__inc)
+
+    def as_datetime(self):
+        """Return a :class:`~datetime.datetime` instance corresponding
+        to the time portion of this :class:`Timestamp`.
+
+        .. versionchanged:: 1.8
+           The returned datetime is now timezone aware.
+        """
+        return datetime.datetime.fromtimestamp(self.__time, utc)

--- a/txmongo/_pymongo/tz_util.py
+++ b/txmongo/_pymongo/tz_util.py
@@ -1,0 +1,45 @@
+# Copyright 2010 10gen, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Timezone related utilities for BSON."""
+
+from datetime import (timedelta,
+                      tzinfo)
+
+ZERO = timedelta(0)
+
+
+class FixedOffset(tzinfo):
+    """Fixed offset timezone, in minutes east from UTC.
+
+    Implementation from the Python `standard library documentation
+    <http://docs.python.org/library/datetime.html#tzinfo-objects>`_.
+    """
+
+    def __init__(self, offset, name):
+        self.__offset = timedelta(minutes=offset)
+        self.__name = name
+
+    def utcoffset(self, dt):
+        return self.__offset
+
+    def tzname(self, dt):
+        return self.__name
+
+    def dst(self, dt):
+        return ZERO
+
+
+utc = FixedOffset(0, "UTC")
+"""Fixed offset timezone representing UTC."""


### PR DESCRIPTION
Hi, here is a patch adding support for Timestamp objects as they exist
in the current pymongo driver, so that you can store timestamps explicitly.

Any interest in something like this?
