### PR TITLE
Fix query failure

### DIFF
--- a/txmongo/protocol.py
+++ b/txmongo/protocol.py
@@ -92,7 +92,7 @@ class MongoProtocol(protocol.Protocol):
         QUERY_FAILURE = 1 << 1
         response_flag, cursor_id, start, length = struct.unpack("<iqii", packet[:20])
         if response_flag == QUERY_FAILURE:
-            self.queryFailure(request_id, cursor_id, response_flag, packet[20:])
+            self.queryFailure(request_id, cursor_id, response_flag, bson._to_dicts(packet[20:]))
             return
         self.querySuccess(request_id, cursor_id, bson._to_dicts(packet[20:]))
 


### PR DESCRIPTION
The response_flag field of an OP_REPLY is incorrectly checked. It is checking for a value of 1 instead of bit-field 1 (index starting from zero in mongodb docs, so value of 2).

This now correctly throws an error instead of returning what is thought to be a valid document with an $err field.
