### PR TITLE
Fix reconnecting for _Connection class in txmongo.connection

### DIFF
--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -136,12 +136,14 @@ class _Connection(ReconnectingClientFactory):
         self.setInstance(instance=proto)
     
     def clientConnectionFailed(self, connector, reason):
+        self.instance = None
         self.auth_set = set()
         if self.continueTrying:
             self.connector = connector
             self.retryNextHost()
     
     def clientConnectionLost(self, connector, reason):
+        self.instance = None
         self.auth_set = set()
         if self.continueTrying:
             self.connector = connector


### PR DESCRIPTION
Fix reconnecting. There is a bug when connection is lost, old (disconnected) proto is used, all deferreds that use this connection don't work properly and requests don't work after reconnnection at all. This is because getprotocol method of ConnectionPool return disconnected proto instance, which should be set to None on disconnection.
