### PR TITLE
Fix resetDelay after retry, import

### DIFF
--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -61,7 +61,7 @@ class _Connection(ReconnectingClientFactory):
         # Update our server configuration. This may disconnect if the node
         # is not a master.
         p.connectionReady().addCallback(lambda _: self.configure(p))\
-                           .addCallback(lambda_: self.resetDelay())
+                           .addCallback(lambda _: self.resetDelay())
         
         return p
     


### PR DESCRIPTION
Fix import of twisted.python.log used in retryNextHost method of txmongo.connection._Connection class.
After success reconnection attributes delay, retries weren't reset. Add it in buildProtocol method.
