### PR TITLE
Fixed 'as_class' argument of find() and find_one() with pymongo 3.0

### DIFF
--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -18,6 +18,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 import txmongo
 from txmongo.protocol import MongoClientProtocol
+from collections import OrderedDict
 
 mongo_host = "localhost"
 mongo_port = 27017
@@ -204,6 +205,16 @@ class TestMongoQueries(unittest.TestCase):
 
         self.assertEqual(len(result), 5)
         self.assertEqual(counter.call_count, 0)
+
+    @defer.inlineCallbacks
+    def test_AsClass(self):
+        yield self.coll.insert({'x': 42})
+
+        doc = yield self.coll.find_one({})
+        self.assertIs(type(doc), dict)
+
+        doc = yield self.coll.find_one({}, as_class=OrderedDict)
+        self.assertIs(type(doc), OrderedDict)
 
     @defer.inlineCallbacks
     def tearDown(self):

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -7,6 +7,9 @@ import types
 from bson import BSON, ObjectId
 from bson.code import Code
 from bson.son import SON
+import pymongo
+if pymongo.version >= '3':
+    from bson.codec_options import CodecOptions
 from pymongo.errors import InvalidName
 from txmongo import filter as qf
 from txmongo.protocol import DELETE_SINGLE_REMOVE, UPDATE_UPSERT, UPDATE_MULTI, \
@@ -161,7 +164,11 @@ class Collection(object):
                 docs_count = min(docs_count, limit - fetched)
             fetched += docs_count
 
-            out = [document.decode(as_class=as_class) for document in documents[:docs_count]]
+            if pymongo.version > '3':
+                options = CodecOptions(document_class=as_class)
+                out = [document.decode(codec_options=options) for document in documents[:docs_count]]
+            else:
+                out = [document.decode(as_class=as_class) for document in documents[:docs_count]]
 
             if reply.cursor_id:
                 if limit == 0:

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -164,7 +164,7 @@ class Collection(object):
                 docs_count = min(docs_count, limit - fetched)
             fetched += docs_count
 
-            if pymongo.version > '3':
+            if pymongo.version >= '3':
                 options = CodecOptions(document_class=as_class)
                 out = [document.decode(codec_options=options) for document in documents[:docs_count]]
             else:


### PR DESCRIPTION
PyMongo 3.0 removed `as_class` argument from BSON.decode as stated in #80
This fix adapts txmongo to this change by using new `CodecOptions` class from PyMongo 3.0 while falling back to `as_class` on 2.x.
Also testcase added for checking `as_class` behavior.