### PR TITLE
OrderedDict replaced by custom dict subclass for the sake of py26

### DIFF
--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -50,8 +50,8 @@ class TestAggregate(unittest.TestCase):
 
         res = yield self.coll.aggregate([{"$match": {"oh": "hai"}}], full_response=True)
 
-        self.assertIn("ok", res)
-        self.assertIn("result", res)
+        self.assertTrue("ok" in res)
+        self.assertTrue("result" in res)
         self.assertEqual(len(res["result"]), 2)
 
     @defer.inlineCallbacks

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -86,7 +86,7 @@ class TestIndexInfo(unittest.TestCase):
         self.assertEqual(self.db.test.test, self.db.test("test"))
 
         options = yield self.db.test.options()
-        self.assertIsInstance(options, dict)
+        self.assertTrue(isinstance(options, dict))
 
         yield self.db.drop_collection("test")
         collection_names = yield self.db.collection_names()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -18,7 +18,6 @@ from twisted.internet import defer
 from twisted.trial import unittest
 import txmongo
 from txmongo.protocol import MongoClientProtocol
-from collections import OrderedDict
 
 mongo_host = "localhost"
 mongo_port = 27017
@@ -213,8 +212,10 @@ class TestMongoQueries(unittest.TestCase):
         doc = yield self.coll.find_one({})
         self.assertIs(type(doc), dict)
 
-        doc = yield self.coll.find_one({}, as_class=OrderedDict)
-        self.assertIs(type(doc), OrderedDict)
+        class CustomDict(dict): pass
+
+        doc = yield self.coll.find_one({}, as_class=CustomDict)
+        self.assertIs(type(doc), CustomDict)
 
     @defer.inlineCallbacks
     def tearDown(self):

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -210,12 +210,12 @@ class TestMongoQueries(unittest.TestCase):
         yield self.coll.insert({'x': 42})
 
         doc = yield self.coll.find_one({})
-        self.assertIs(type(doc), dict)
+        self.assertTrue(type(doc) is dict)
 
         class CustomDict(dict): pass
 
         doc = yield self.coll.find_one({}, as_class=CustomDict)
-        self.assertIs(type(doc), CustomDict)
+        self.assertTrue(type(doc) is CustomDict)
 
     @defer.inlineCallbacks
     def tearDown(self):


### PR DESCRIPTION
Python 2.6 doesn't have OrderedDict, so I replaced it with custom one-line `dict` subclass for testing `as_class` parameter of `find()`