### PR TITLE
Tests that encode and decode protocol messages and compare results

### DIFF
--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -37,13 +37,11 @@ class _FakeTransport(object):
 
 class TestMongoProtocol(unittest.TestCase):
 
-    def __test_encode_decode(self, method, request):
-        # `method` is unbound send_* method of MongoClientProtocol
-
+    def __test_encode_decode(self, request):
         proto = MongoClientProtocol()
         proto.transport = _FakeTransport()
 
-        method(proto, request)
+        proto.send(request)
 
         decoder = MongoDecoder()
         decoder.feed(proto.transport.get_content())
@@ -59,27 +57,27 @@ class TestMongoProtocol(unittest.TestCase):
         request = Query(collection="coll", n_to_skip=123, n_to_return=456,
                         query=BSON.encode({'x': 42}),
                         fields=BSON.encode({'y': 1}))
-        self.__test_encode_decode(MongoClientProtocol.send_QUERY, request)
+        self.__test_encode_decode(request)
 
     def test_EncodeDecodeKillCursors(self):
         request = KillCursors(cursors=[0x12345678, 0x87654321])
-        self.__test_encode_decode(MongoClientProtocol.send_KILL_CURSORS, request)
+        self.__test_encode_decode(request)
 
     def test_EncodeDecodeGetmore(self):
         request = Getmore(collection="coll", cursor_id=0x12345678, n_to_return=5)
-        self.__test_encode_decode(MongoClientProtocol.send_GETMORE, request)
+        self.__test_encode_decode(request)
 
     def test_EncodeDecodeInsert(self):
         request = Insert(collection="coll", documents=[BSON.encode({'x': 42})])
-        self.__test_encode_decode(MongoClientProtocol.send_INSERT, request)
+        self.__test_encode_decode(request)
 
     def test_EncodeDecodeUpdate(self):
         request = Update(flags=UPDATE_MULTI|UPDATE_UPSERT, collection="coll",
                          selector=BSON.encode({'x': 42}),
                          update=BSON.encode({"$set": {'y': 123}}))
-        self.__test_encode_decode(MongoClientProtocol.send_UPDATE, request)
+        self.__test_encode_decode(request)
 
     def test_EncodeDecodeDelete(self):
         request = Delete(flags=DELETE_SINGLE_REMOVE, collection="coll",
                          selector=BSON.encode({'x': 42}))
-        self.__test_encode_decode(MongoClientProtocol.send_DELETE, request)
+        self.__test_encode_decode(request)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,85 @@
+# coding: utf-8
+# Copyright 2010 Mark L.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from bson import BSON
+from twisted.trial import unittest
+from twisted.internet import defer
+
+from txmongo.protocol import MongoClientProtocol, MongoDecoder, Insert, Query, \
+    KillCursors, Getmore, Update, Delete, UPDATE_MULTI, UPDATE_UPSERT, \
+    DELETE_SINGLE_REMOVE
+
+
+class _FakeTransport(object):
+    "Catches all content that MongoClientProtocol wants to send over the wire"
+
+    def __init__(self):
+        self.data = []
+
+    def write(self, data):
+        self.data.append(data)
+
+    def get_content(self):
+        return ''.join(self.data)
+
+
+class TestMongoProtocol(unittest.TestCase):
+
+    def __test_encode_decode(self, method, request):
+        # `method` is unbound send_* method of MongoClientProtocol
+
+        proto = MongoClientProtocol()
+        proto.transport = _FakeTransport()
+
+        method(proto, request)
+
+        decoder = MongoDecoder()
+        decoder.feed(proto.transport.get_content())
+        decoded = decoder.next()
+
+        for field, dec_value, req_value in zip(request._fields, decoded, request):
+            # len and request_id are not filled in request object
+            if field not in ("len", "request_id"):
+                self.assertEqual(dec_value, req_value)
+
+
+    def test_EncodeDecodeQuery(self):
+        request = Query(collection="coll", n_to_skip=123, n_to_return=456,
+                        query=BSON.encode({'x': 42}),
+                        fields=BSON.encode({'y': 1}))
+        self.__test_encode_decode(MongoClientProtocol.send_QUERY, request)
+
+    def test_EncodeDecodeKillCursors(self):
+        request = KillCursors(cursors=[0x12345678, 0x87654321])
+        self.__test_encode_decode(MongoClientProtocol.send_KILL_CURSORS, request)
+
+    def test_EncodeDecodeGetmore(self):
+        request = Getmore(collection="coll", cursor_id=0x12345678, n_to_return=5)
+        self.__test_encode_decode(MongoClientProtocol.send_GETMORE, request)
+
+    def test_EncodeDecodeInsert(self):
+        request = Insert(collection="coll", documents=[BSON.encode({'x': 42})])
+        self.__test_encode_decode(MongoClientProtocol.send_INSERT, request)
+
+    def test_EncodeDecodeUpdate(self):
+        request = Update(flags=UPDATE_MULTI|UPDATE_UPSERT, collection="coll",
+                         selector=BSON.encode({'x': 42}),
+                         update=BSON.encode({"$set": {'y': 123}}))
+        self.__test_encode_decode(MongoClientProtocol.send_UPDATE, request)
+
+    def test_EncodeDecodeDelete(self):
+        request = Delete(flags=DELETE_SINGLE_REMOVE, collection="coll",
+                         selector=BSON.encode({'x': 42}))
+        self.__test_encode_decode(MongoClientProtocol.send_DELETE, request)


### PR DESCRIPTION
A bunch of tests that encode protocol messages into bytes and then decode them using `txmongo.protocol.MongoDecoder` and compare decoded object with original request object.

This might be considered as additional check for encoding code. Also this will add test coverage for `MongoDecoder` class.