### PR TITLE
Trying to fix "reactor unclean" test fails

### DIFF
--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -17,7 +17,7 @@ from twisted.internet import defer
 from twisted.trial import unittest
 import txmongo
 
-mongo_host = "localhost"
+mongo_host = "127.0.0.1"
 mongo_port = 27017
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -17,7 +17,7 @@ from twisted.trial import unittest
 from twisted.internet import base, defer
 import txmongo
 
-mongo_host = "localhost"
+mongo_host = "127.0.0.1"
 mongo_port = 27017
 base.DelayedCall.debug = True
 
@@ -25,8 +25,8 @@ base.DelayedCall.debug = True
 class TestMongoConnection(unittest.TestCase):
 
     def setUp(self):
-        self.named_conn = txmongo.connection.ConnectionPool("mongodb://localhost/dbname")
-        self.unnamed_conn = txmongo.connection.ConnectionPool("mongodb://localhost/")
+        self.named_conn = txmongo.connection.ConnectionPool("mongodb://127.0.0.1/dbname")
+        self.unnamed_conn = txmongo.connection.ConnectionPool("mongodb://127.0.0.1/")
 
     @defer.inlineCallbacks
     def tearDown(self):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -25,7 +25,7 @@ from txmongo._gridfs import GridIn
 from twisted.trial import unittest
 from twisted.internet import base, defer
 
-mongo_host = "localhost"
+mongo_host = "127.0.0.1"
 mongo_port = 27017
 base.DelayedCall.debug = True
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -35,7 +35,7 @@ class _CallCounter(object):
 
 class TestMongoQueries(unittest.TestCase):
 
-    timeout = 5
+    timeout = 15
 
     @defer.inlineCallbacks
     def setUp(self):
@@ -231,7 +231,7 @@ class TestMongoQueries(unittest.TestCase):
 
 class TestMongoQueriesEdgeCases(unittest.TestCase):
 
-    timeout = 5
+    timeout = 15
 
     @defer.inlineCallbacks
     def setUp(self):
@@ -264,7 +264,7 @@ class TestMongoQueriesEdgeCases(unittest.TestCase):
 
 class TestLimit(unittest.TestCase):
 
-    timeout = 5
+    timeout = 15
 
     @defer.inlineCallbacks
     def setUp(self):
@@ -327,7 +327,7 @@ class TestLimit(unittest.TestCase):
 
 class TestSkip(unittest.TestCase):
 
-    timeout = 5
+    timeout = 15
 
     @defer.inlineCallbacks
     def setUp(self):


### PR DESCRIPTION
I've looked into sporadically failed tests and found that this happens for tests that create MongoConnection and immediately call its disconnect() without issuing any queries. MongoConnection() constructor starts connecting in background. Connection process in turn starts name resolution of "localhost" into ip-address. If name resolution doesn't finish until disconnect() returns (it takes exactly 1 main loop round-trip), trial fails with "reactor unclean". (Name resolution is deferred to separate thread, so there is race condition which fails more often on slow machines).

Unfortunately, I didn't found any good way to wait until name resolution is done :(

The simpliest way to solve this is to change "localhost" to "127.0.0.1" in test_queries.py, test_aggregate.py and test_connection.py. Or to issue any command on MongoConnection in corresponding test methods.

After changing "localhost" to "127.0.0.1" I'm not able to reproduce this anymore.

Lets see what Travis will say