### PR TITLE
db.command() method

### DIFF
--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -228,17 +228,11 @@ class TestIndexInfo(unittest.TestCase):
         yield coll.create_index(filter.sort(filter.GEOHAYSTACK("pos") +
                                             filter.ASCENDING("type")), **{"bucket_size": 1})
 
-        # TODO: A db.command method has not been implemented yet.
-        # Sending command directly
-        command = SON([
-            ("geoSearch", "mycol"),
-            ("near", [33, 33]),
-            ("maxDistance", 6),
-            ("search", {"type": "restaurant"}),
-            ("limit", 30),
-        ])
-           
-        results = yield db["$cmd"].find_one(command)
+        results = yield db.command("geoSearch", "mycol",
+                                   near=[33, 33],
+                                   maxDistance=6,
+                                   search={"type": "restaurant"},
+                                   limit=30)
         self.assertEqual(2, len(results["results"]))
         self.assertEqual({
             "_id": _id,

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -79,9 +79,9 @@ class TestMongoFilters(unittest.TestCase):
     def __test_simple_filter(self, filter, optionname, optionvalue):
         # Checking that `optionname` appears in profiler log with specified value
 
-        yield self.db["$cmd"].find_one({"profile": 2})
+        yield self.db.command("profile", 2)
         yield self.coll.find({}, filter=filter)
-        yield self.db["$cmd"].find_one({"profile": 0})
+        yield self.db.command("profile", 0)
 
         cnt = yield self.db.system.profile.count({"query." + optionname: optionvalue})
         self.assertEqual(cnt, 1)
@@ -108,9 +108,9 @@ class TestMongoFilters(unittest.TestCase):
 
         comment = "hello world"
 
-        yield self.db["$cmd"].find_one({"profile": 2})
+        yield self.db.command("profile", 2)
         yield self.coll.find({}, filter=qf.sort(qf.ASCENDING('x')) + qf.comment(comment))
-        yield self.db["$cmd"].find_one({"profile": 0})
+        yield self.db.command("profile", 0)
 
         cnt = yield self.db.system.profile.count({"query.$orderby.x": 1,
                                                   "query.$comment": comment})

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -41,9 +41,6 @@ class TestMongoFilters(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_Hint(self):
-        # Ensure there is no {x:1} index
-        yield self.coll.drop_index(qf.sort([('x', 1)]))
-
         # find() should fail with 'bad hint' if hint specifier works correctly
         self.assertFailure(self.coll.find({}, filter=qf.hint([('x', 1)])), OperationFailure)
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -149,7 +149,7 @@ class TestMongoQueries(unittest.TestCase):
 
     @defer.inlineCallbacks
     def __check_no_open_cursors(self):
-        status = yield self.db["$cmd"].find_one({"serverStatus": 1})
+        status = yield self.db.command("serverStatus")
         if "cursor" in status["metrics"]:
             self.assertEqual(status["metrics"]["cursor"]["open"]["total"], 0)
         else:

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -418,12 +418,12 @@ class TestCommand(unittest.TestCase):
     def test_CheckResult(self):
         yield self.coll.insert([{'x': 42}, {'y': 123}], safe=True)
 
-        # Passing number as collection name
-        self.assertFailure(self.db.command("count", 1234), OperationFailure)
+        # missing 'deletes' argument
+        self.assertFailure(self.db.command("delete", "mycol"), OperationFailure)
 
-        result = yield self.db.command("count", 1234, check=False)
+        result = yield self.db.command("delete", "mycol", check=False)
         self.assertFalse(result["ok"])
 
-        result = yield self.db.command("count", 1234, check=True,
-                                       allowable_errors=["collection name missing"])
+        result = yield self.db.command("delete", "mycol", check=True,
+                                       allowable_errors=["missing deletes field"])
         self.assertFalse(result["ok"])

--- a/tests/test_replicaset.py
+++ b/tests/test_replicaset.py
@@ -55,7 +55,7 @@ class TestReplicaSet(unittest.TestCase):
 
         master_uri = "mongodb://localhost:{0}/?readPreference=secondaryPreferred".format(self.ports[0])
         master = ConnectionPool(master_uri)
-        yield master.admin["$cmd"].find_one({"replSetInitiate": self.rsconfig})
+        yield master.admin.command("replSetInitiate", self.rsconfig)
 
         ready = False
         n_tries = int(self.__init_timeout / self.__ping_interval)
@@ -66,8 +66,8 @@ class TestReplicaSet(unittest.TestCase):
             # to be sure that replica set is up and running, primary is elected and all
             # secondaries are in sync and ready to became new primary
 
-            ismaster_req = master.admin["$cmd"].find_one({"ismaster": 1})
-            replstatus_req = master.admin["$cmd"].find_one({"replSetGetStatus": 1})
+            ismaster_req = master.admin.command("ismaster")
+            replstatus_req = master.admin.command("replSetGetStatus")
             ismaster, replstatus = yield defer.gatherResults([ismaster_req, replstatus_req])
 
             initialized = replstatus["ok"]

--- a/tests/test_replicaset.py
+++ b/tests/test_replicaset.py
@@ -66,8 +66,8 @@ class TestReplicaSet(unittest.TestCase):
             # to be sure that replica set is up and running, primary is elected and all
             # secondaries are in sync and ready to became new primary
 
-            ismaster_req = master.admin.command("ismaster")
-            replstatus_req = master.admin.command("replSetGetStatus")
+            ismaster_req = master.admin.command("ismaster", check=False)
+            replstatus_req = master.admin.command("replSetGetStatus", check=False)
             ismaster, replstatus = yield defer.gatherResults([ismaster_req, replstatus_req])
 
             initialized = replstatus["ok"]

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -394,7 +394,7 @@ class Collection(object):
 
         return self._database.command("deleteIndexes", self._collection_name,
                                       index=name,
-                                      check=False)
+                                      allowable_errors=["ns not found"])
 
     def drop_indexes(self):
         return self.drop_index("*")

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -216,10 +216,9 @@ class Collection(object):
                 fields = ["_id"]
             fields = self._fields_list_to_dict(fields)
 
-        spec = SON([("count", self._collection_name),
-                    ("query", spec or SON()),
-                    ("fields", fields)])
-        deferred_find_one = self._database["$cmd"].find_one(spec)
+        deferred_find_one = self._database.command("count", self._collection_name,
+                                                   query=spec or SON(),
+                                                   fields=fields)
         deferred_find_one.addCallback(wrapper)
         return deferred_find_one
 
@@ -240,7 +239,7 @@ class Collection(object):
         if finalize:
             body["finalize"] = Code(finalize)
 
-        return self._database["$cmd"].find_one({"group": body})
+        return self._database.command("group", body)
 
     def filemd5(self, spec):
         def wrapper(result):
@@ -250,10 +249,7 @@ class Collection(object):
             raise ValueError("filemd5 expected an objectid for its "
                              "non-keyword argument")
 
-        spec = SON([("filemd5", spec),
-                    ("root", self._collection_name)])
-
-        deferred_fine_one = self._database["$cmd"].find_one(spec)
+        deferred_fine_one = self._database.command("filemd5", spec, root=self._collection_name)
         deferred_fine_one.addCallback(wrapper)
         return deferred_fine_one
 
@@ -396,8 +392,9 @@ class Collection(object):
         else:
             raise TypeError("index_identifier must be a name or instance of filter.sort")
 
-        cmd = SON([("deleteIndexes", self._collection_name), ("index", name)])
-        return self._database["$cmd"].find_one(cmd)
+        return self._database.command("deleteIndexes", self._collection_name,
+                                      index=name,
+                                      check=False)
 
     def drop_indexes(self):
         return self.drop_index("*")
@@ -414,9 +411,8 @@ class Collection(object):
         return deferred_find
 
     def rename(self, new_name):
-        cmd = SON([("renameCollection", str(self)),
-                   ("to", "%s.%s" % (str(self._database), new_name))])
-        return self._database("admin")["$cmd"].find_one(cmd)
+        to = "%s.%s" % (str(self._database), new_name)
+        return self._database("admin").command("renameCollection", str(self), to=to)
 
     def distinct(self, key, spec=None):
         def wrapper(result):
@@ -424,11 +420,11 @@ class Collection(object):
                 return result.get("values")
             return {}
 
-        cmd = SON([("distinct", self._collection_name), ("key", key)])
+        params = {"key": key}
         if spec:
-            cmd["query"] = spec
+            params["query"] = spec
 
-        d = self._database["$cmd"].find_one(cmd)
+        d = self._database.command("distinct", self._collection_name, **params)
         d.addCallback(wrapper)
         return d
 
@@ -438,10 +434,7 @@ class Collection(object):
                 return result
             return result.get("result")
 
-        cmd = SON([("aggregate", self._collection_name),
-                   ("pipeline", pipeline)])
-
-        d = self._database["$cmd"].find_one(cmd)
+        d = self._database.command("aggregate", self._collection_name, pipeline=pipeline)
         d.addCallback(wrapper, full_response)
         return d
 
@@ -451,10 +444,9 @@ class Collection(object):
                 return result
             return result.get("result")
 
-        cmd = SON([("mapreduce", self._collection_name),
-                   ("map", map), ("reduce", reduce)])
-        cmd.update(**kwargs)
-        deferred_find_one = self._database["$cmd"].find_one(cmd)
+        params = {"map": map, "reduce": reduce}
+        params.update(**kwargs)
+        deferred_find_one = self._database.command("mapreduce", self._collection_name, **params)
         deferred_find_one.addCallback(wrapper, full_response)
         return deferred_find_one
 
@@ -474,16 +466,16 @@ class Collection(object):
         if update and kwargs.get("remove", None):
             raise ValueError("Can't do both update and remove")
 
-        cmd = SON([("findAndModify", self._collection_name)])
-        cmd.update(kwargs)
+        params = kwargs
         # No need to include empty args
         if query:
-            cmd["query"] = query
+            params["query"] = query
         if update:
-            cmd["update"] = update
+            params["update"] = update
         if upsert:
-            cmd["upsert"] = upsert
+            params["upsert"] = upsert
 
-        deferred_find_one = self._database["$cmd"].find_one(cmd)
+        deferred_find_one = self._database.command("findAndModify", self._collection_name,
+                                                   **params)
         deferred_find_one.addCallback(wrapper)
         return deferred_find_one

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -82,7 +82,7 @@ class Database(object):
         else:
             raise TypeError("name must be an instance of basestring or txmongo.Collection")
 
-        return self.command("drop", unicode(name), check=False)
+        return self.command("drop", unicode(name), allowable_errors=["ns not found"])
 
     def collection_names(self):
         def wrapper(results):

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -41,7 +41,7 @@ class Database(object):
     @defer.inlineCallbacks
     def command(self, command, value=1, check=True, allowable_errors=None, **kwargs):
         if isinstance(command, basestring):
-            command = {command: value}
+            command = SON([(command, value)])
         command.update(kwargs)
 
         ns = self["$cmd"]

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -67,9 +67,7 @@ class Database(object):
             if "size" in options:
                 options["size"] = float(options["size"])
 
-            command = SON({"create": name})
-            command.update(options)
-            d = self["$cmd"].find_one(command)
+            d = self.command("create", name, **options)
             d.addCallback(wrapper, deferred, collection)
         else:
             deferred.callback(collection)
@@ -84,7 +82,7 @@ class Database(object):
         else:
             raise TypeError("name must be an instance of basestring or txmongo.Collection")
 
-        return self["$cmd"].find_one({"drop": unicode(name)})
+        return self.command("drop", unicode(name), check=False)
 
     def collection_names(self):
         def wrapper(results):

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -55,10 +55,7 @@ class Database(object):
 
     def create_collection(self, name, options=None):
         def wrapper(result, deferred, collection):
-            if result.get("ok", 0.0):
-                deferred.callback(collection)
-            else:
-                deferred.errback(RuntimeError(result.get("errmsg", "unknown error")))
+            deferred.callback(collection)
 
         deferred = defer.Deferred()
         collection = Collection(self, name)


### PR DESCRIPTION
Signature and behavior are same as in PyMongo

Almost all occurences of `db["$cmd"].find_one()` replaced with this new method.

Since `db.command()` has integrated simple error-checking, redundant checks were removed in some methods that are using this new method.