### PR TITLE
coll.rename() fix and additional tests

### DIFF
--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -245,3 +245,26 @@ class TestIndexInfo(unittest.TestCase):
             "pos": {"long": 34.2, "lat": 33.3},
             "type": "restaurant"
         }, results["results"][0])
+
+
+class TestRename(unittest.TestCase):
+
+    def setUp(self):
+        self.conn = txmongo.MongoConnection(mongo_host, mongo_port)
+        self.db = self.conn.mydb
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.conn.disconnect()
+
+    @defer.inlineCallbacks
+    def test_Rename(self):
+        coll = yield self.db.create_collection("coll1")
+        yield coll.insert({'x': 42}, safe=True)
+
+        yield coll.rename("coll2")
+
+        doc = yield self.db.coll2.find_one(fields={"_id": 0})
+        self.assertEqual(doc, {'x': 42})
+
+        yield self.db.coll2.drop()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -268,3 +268,38 @@ class TestRename(unittest.TestCase):
         self.assertEqual(doc, {'x': 42})
 
         yield self.db.coll2.drop()
+
+
+class TestOptions(unittest.TestCase):
+
+    def setUp(self):
+        self.conn = txmongo.MongoConnection(mongo_host, mongo_port)
+        self.db = self.conn.mydb
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.conn.disconnect()
+
+    @defer.inlineCallbacks
+    def test_Options(self):
+        coll = yield self.db.create_collection("opttest", {"capped": True, "size": 4096})
+        self.assertTrue(isinstance(coll, Collection))
+
+        opts = yield coll.options()
+        self.assertEqual(opts["capped"], True)
+        self.assertEqual(opts["size"], 4096)
+
+        yield coll.drop()
+
+    @defer.inlineCallbacks
+    def test_NonExistingCollection(self):
+        opts = yield self.db.nonexisting.options()
+        self.assertEqual(opts, {})
+
+    @defer.inlineCallbacks
+    def test_WithoutOptions(self):
+        coll = yield self.db.create_collection("opttest")
+        opts = yield coll.options()
+        self.assertEqual(opts, {})
+
+        yield coll.drop()

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -21,7 +21,7 @@ class Database(object):
         return "Database(%r, %r)" % (self.__factory, self._database_name,)
 
     def __call__(self, database_name):
-        return Database(self._factory, database_name)
+        return Database(self.__factory, database_name)
 
     def __getitem__(self, collection_name):
         return Collection(self, collection_name)


### PR DESCRIPTION
I've added tests for `coll.rename()` and `coll.options()`

While testing `Collection.rename()` I've also noticed a typo in `Database.__call__()` that made `Collection.rename()` completely non-working :)