### PR TITLE
Proper failure of create_collection instead of hang in case of error

### DIFF
--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -297,3 +297,28 @@ class TestOptions(unittest.TestCase):
         self.assertEqual(opts, {})
 
         yield coll.drop()
+
+
+class TestCreateCollection(unittest.TestCase):
+
+    def setUp(self):
+        self.conn = txmongo.MongoConnection(mongo_host, mongo_port)
+        self.db = self.conn.mydb
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.conn.disconnect()
+
+    @defer.inlineCallbacks
+    def test_Fail(self):
+        # Not using assertFailure() here because it doesn't wait until deferred is
+        # resolved or failed but there was a bug that made deferred hang forever
+        # in case if create_collection failed
+        try:
+            # Negative size
+            yield self.db.create_collection("opttest", {"size": -100})
+        except errors.OperationFailure as e:
+            pass
+        else:
+            self.fail()
+    test_Fail.timeout = 10

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -66,6 +66,7 @@ class Database(object):
 
             d = self.command("create", name, **options)
             d.addCallback(wrapper, deferred, collection)
+            d.addErrback(deferred.errback)
         else:
             deferred.callback(collection)
 


### PR DESCRIPTION
If `create_collection` is failing, it doesn't calls errback on deferred it returns, so calling code will hang forever