### PR TITLE
Additional tests for collection.py and small fix for map_reduce()

### DIFF
--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -21,7 +21,6 @@ from pymongo import errors
 
 from twisted.internet import defer
 from twisted.trial import unittest
-from unittest import SkipTest
 
 import txmongo
 
@@ -151,7 +150,7 @@ class TestIndexInfo(unittest.TestCase):
         # dropDups was removed from MongoDB v3.0
         ismaster = yield self.db.command("ismaster")
         if ismaster["maxWireVersion"] >= 3:
-            raise SkipTest()
+            raise unittest.SkipTest()
 
         yield self.coll.drop()
         yield self.coll.insert([{'b': 1}, {'b': 1}])

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -21,6 +21,7 @@ from pymongo import errors
 
 from twisted.internet import defer
 from twisted.trial import unittest
+from unittest import SkipTest
 
 import txmongo
 
@@ -146,6 +147,21 @@ class TestIndexInfo(unittest.TestCase):
         yield self.assertFailure(ix, errors.DuplicateKeyError)
 
     @defer.inlineCallbacks
+    def test_create_index_dropdups(self):
+        # dropDups was removed from MongoDB v3.0
+        ismaster = yield self.db.command("ismaster")
+        if ismaster["maxWireVersion"] >= 3:
+            raise SkipTest()
+
+        yield self.coll.drop()
+        yield self.coll.insert([{'b': 1}, {'b': 1}])
+
+        ix = yield self.coll.create_index(filter.sort(filter.ASCENDING('b')),
+                                          unique=True, drop_dups=True)
+        docs = yield self.coll.find(fields={"_id": 0})
+        self.assertEqual(docs, [{'b': 1}])
+
+    @defer.inlineCallbacks
     def test_ensure_index(self):
         db = self.db
         coll = self.coll
@@ -239,6 +255,23 @@ class TestIndexInfo(unittest.TestCase):
             "pos": {"long": 34.2, "lat": 33.3},
             "type": "restaurant"
         }, results["results"][0])
+
+
+    @defer.inlineCallbacks
+    def test_drop_index(self):
+        yield self.coll.drop_indexes()
+
+        index = filter.sort(filter.ASCENDING("hello") + filter.DESCENDING("world"))
+
+        yield self.coll.create_index(index, name="myindex")
+        res = yield self.coll.drop_index("myindex")
+        self.assertEqual(res["ok"], 1)
+
+        yield self.coll.create_index(index)
+        res = yield self.coll.drop_index(index)
+        self.assertEqual(res["ok"], 1)
+
+        self.assertRaises(TypeError, self.coll.drop_index, 123)
 
 
 class TestRename(unittest.TestCase):

--- a/tests/test_find_and_modify.py
+++ b/tests/test_find_and_modify.py
@@ -23,8 +23,6 @@ mongo_port = 27017
 
 class TestFindAndModify(unittest.TestCase):
 
-    timeout = 5
-
     @defer.inlineCallbacks
     def setUp(self):
         self.conn = yield txmongo.MongoConnection(mongo_host, mongo_port)

--- a/tests/test_find_and_modify.py
+++ b/tests/test_find_and_modify.py
@@ -49,6 +49,26 @@ class TestFindAndModify(unittest.TestCase):
         res = yield self.coll.find_one({"oh": "kthxbye"})
         self.assertEqual(res["lulz"], 456)
 
+    def test_InvalidOptions(self):
+        self.assertRaises(ValueError, self.coll.find_and_modify)
+        self.assertRaises(ValueError, self.coll.find_and_modify,
+                          update={"$set": {'x': 42}},
+                          remove=True)
+
+    @defer.inlineCallbacks
+    def test_Remove(self):
+        yield self.coll.insert({'x': 42})
+        doc = yield self.coll.find_and_modify(remove=True)
+        self.assertEqual(doc['x'], 42)
+        cnt = yield self.coll.count()
+        self.assertEqual(cnt, 0)
+
+    @defer.inlineCallbacks
+    def test_Upsert(self):
+        yield self.coll.find_and_modify({'x': 42}, update={"$set": {'y': 123}}, upsert=True)
+        docs = yield self.coll.find(fields={"_id": 0})
+        self.assertEqual(docs, [{'x': 42, 'y': 123}])
+
 
     @defer.inlineCallbacks
     def tearDown(self):

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -440,7 +440,7 @@ class Collection(object):
         def wrapper(result, full_response):
             if full_response:
                 return result
-            return result.get("result")
+            return result.get("results")
 
         params = {"map": map, "reduce": reduce}
         params.update(**kwargs)


### PR DESCRIPTION
Before refactoring some methods of `collection.py` to use `inlineCallbacks`, i'd like to have each code path covered by tests.

Now `collection.py` is 100%-covered except for lines that should never  be reached or should not be reached with library versions we use in testing environment (pymongo==3.0).

While doing tests for `map_reduce()` I've found typo that made it useless without `full_response=True` :)