### PR TITLE
inlineCallbacks everywhere

### DIFF
--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -65,7 +65,7 @@ class TestIndexInfo(unittest.TestCase):
         self.assertRaises(errors.InvalidName, make_col, self.db.test, "tes..t")
         self.assertRaises(errors.InvalidName, make_col, self.db.test, "tes\x00t")
         self.assertRaises(TypeError, self.coll.save, "test")
-        self.assertRaises(ValueError, self.coll.filemd5, "test")
+        self.assertFailure(self.coll.filemd5("test"), ValueError)
         self.assertFailure(self.db.test.find(spec="test"), TypeError)
         self.assertFailure(self.db.test.find(fields="test"), TypeError)
         self.assertFailure(self.db.test.find(skip="test"), TypeError)
@@ -97,8 +97,8 @@ class TestIndexInfo(unittest.TestCase):
         db = self.db
         coll = self.coll
 
-        self.assertRaises(TypeError, coll.create_index, 5)
-        self.assertRaises(TypeError, coll.create_index, {"hello": 1})
+        self.assertFailure(coll.create_index(5), TypeError)
+        self.assertFailure(coll.create_index({"hello": 1}), TypeError)
 
         yield coll.insert({'c': 1})  # make sure collection exists.
 

--- a/tests/test_find_and_modify.py
+++ b/tests/test_find_and_modify.py
@@ -50,10 +50,9 @@ class TestFindAndModify(unittest.TestCase):
         self.assertEqual(res["lulz"], 456)
 
     def test_InvalidOptions(self):
-        self.assertRaises(ValueError, self.coll.find_and_modify)
-        self.assertRaises(ValueError, self.coll.find_and_modify,
-                          update={"$set": {'x': 42}},
-                          remove=True)
+        self.assertFailure(self.coll.find_and_modify(), ValueError)
+        self.assertFailure(self.coll.find_and_modify(update={"$set": {'x': 42}}, remove=True),
+                           ValueError)
 
     @defer.inlineCallbacks
     def test_Remove(self):


### PR DESCRIPTION
I've refactored a bunch of methods to use inlineCallbacks-style where it is applicable.
Main exception is the `find_with_cursor()` which has unusual recurring deferreds semantics.

As a consequence, a couple of tests were altered to use `assertFailure` instead of `assertRaises` since `@inlineCallbacks` returns failed deferred in case of errros instead of direct raising exceptions.