### PR TITLE
find_one() modified to return None instead of {} when nothing found

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -17,7 +17,7 @@ API Changes
 ^^^^^^^^^^^
 
 - Better handling of replica-sets, we now raise an ``autoreconnect`` when master is unreachable.
-- Changed the behaviour of ``find`` and ``find_one`` to return ``None`` instead of an empty
+- Changed the behaviour of ``find_one`` to return ``None`` instead of an empty
  dict ``{}`` when no result is found.
 
 Features

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -226,6 +226,11 @@ class TestMongoQueries(unittest.TestCase):
         self.assertTrue(type(doc) is CustomDict)
 
     @defer.inlineCallbacks
+    def test_FindOneNone(self):
+        doc = yield self.coll.find_one()
+        self.assertEqual(doc, None)
+
+    @defer.inlineCallbacks
     def tearDown(self):
         yield self.coll.drop()
         yield self.conn.disconnect()

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -202,7 +202,7 @@ class Collection(object):
         if isinstance(spec, ObjectId):
             spec = {"_id": spec}
         result = yield self.find(spec=spec, limit=1, fields=fields, **kwargs)
-        defer.returnValue(result[0] if result else {})
+        defer.returnValue(result[0] if result else None)
 
 
     @defer.inlineCallbacks


### PR DESCRIPTION
This change relates only to `find_one`, `find` still returns empty list when nothing was found