### PR TITLE
Write concern

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ wheel
 setuptools
 tox
 check-manifest
+mock

--- a/tests/test_write_concern.py
+++ b/tests/test_write_concern.py
@@ -1,0 +1,152 @@
+# coding: utf-8
+# Copyright 2015 Ilya Skriblovsky <ilyaskriblovsky@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import Mock, patch
+from twisted.internet import defer
+from twisted.trial import unittest
+from txmongo.connection import MongoConnection, ConnectionPool
+from txmongo.protocol import MongoProtocol
+from txmongo.database import Database
+from txmongo.collection import Collection
+from txmongo.write_concern import WriteConcern
+
+mongo_host = "localhost"
+mongo_port = 27017
+
+class TestWriteConcern(unittest.TestCase):
+
+    def mock_gle(self):
+        return patch("txmongo.protocol.MongoProtocol.get_last_error")
+
+    @defer.inlineCallbacks
+    def test_Priority(self):
+        """
+            Check that connection-level, database-level, collection-level
+            and query-level write concerns are respected with correct priority
+        """
+        conn = MongoConnection(mongo_host, mongo_port, w=1, wtimeout=500)
+
+        try:
+            with self.mock_gle() as mock:
+                yield conn.mydb.mycol.insert({'x': 42})
+                mock.assert_called_once_with("mydb", w=1, wtimeout=500)
+
+            db_w0 = Database(conn, "mydb", write_concern=WriteConcern(w=0))
+            with self.mock_gle() as mock:
+                yield db_w0.mycol.insert({'x': 42})
+                self.assertFalse(mock.called)
+
+            coll = Collection(db_w0, "mycol", write_concern=WriteConcern(w=2))
+            with self.mock_gle() as mock:
+                yield coll.insert({'x': 42})
+                mock.assert_called_once_with("mydb", w=2)
+
+            with self.mock_gle() as mock:
+                yield coll.insert({'x': 42}, j=True)
+                mock.assert_called_once_with("mydb", j=True)
+
+        finally:
+            yield conn.mydb.mycol.drop()
+            yield conn.disconnect()
+
+
+    @defer.inlineCallbacks
+    def test_Safe(self):
+        conn = MongoConnection(mongo_host, mongo_port, w=1, wtimeout=500)
+        coll = conn.mydb.mycol
+
+        try:
+            with self.mock_gle() as mock:
+                yield coll.insert({'x': 42})
+                mock.assert_called_once_with("mydb", w=1, wtimeout=500)
+
+            with self.mock_gle() as mock:
+                yield coll.insert({'x': 42}, safe=False)
+                self.assertFalse(mock.called)
+
+            with self.mock_gle() as mock:
+                yield coll.insert({'x': 42}, safe=True)
+                mock.assert_called_once_with("mydb", w=1, wtimeout=500)
+        finally:
+            yield coll.drop()
+            yield conn.disconnect()
+
+    @defer.inlineCallbacks
+    def test_SafeWithDefaultW0(self):
+        conn = MongoConnection(mongo_host, mongo_port, w=0)
+        coll = conn.mydb.mycol
+
+        try:
+            with self.mock_gle() as mock:
+                yield coll.insert({'x': 42})
+                self.assertFalse(mock.called)
+
+            with self.mock_gle() as mock:
+                yield coll.insert({'x': 42}, safe=False)
+                self.assertFalse(mock.called)
+
+            with self.mock_gle() as mock:
+                yield coll.insert({'x': 42}, safe=True)
+                mock.assert_called_once_with("mydb")
+        finally:
+            yield coll.drop()
+            yield conn.disconnect()
+
+
+    @defer.inlineCallbacks
+    def __test_operation(self, coll, method, *args):
+        with self.mock_gle() as mock:
+            yield getattr(coll, method)(*args)
+            self.assertFalse(mock.called)
+
+        with self.mock_gle() as mock:
+            yield getattr(coll, method)(*args, safe=True)
+            mock.assert_called_once_with("mydb")
+
+        with self.mock_gle() as mock:
+            yield getattr(coll, method)(*args, safe=False)
+            self.assertFalse(mock.called)
+
+        with self.mock_gle() as mock:
+            yield getattr(coll, method)(*args, w=1)
+            mock.assert_called_once_with("mydb", w=1)
+
+    @defer.inlineCallbacks
+    def test_AllOperations(self):
+        conn = MongoConnection(mongo_host, mongo_port, w=0)
+        coll = conn.mydb.mycol
+
+        try:
+            yield self.__test_operation(coll, "insert", {'x': 42})
+            yield self.__test_operation(coll, "update", {}, {'x': 42})
+            yield self.__test_operation(coll, "save", {'x': 42})
+            yield self.__test_operation(coll, "remove", {})
+        finally:
+            yield coll.drop()
+            yield conn.disconnect()
+
+
+    @defer.inlineCallbacks
+    def test_ConnectionUrlParams(self):
+        conn = ConnectionPool("mongodb://{0}:{1}/?w=2&j=true".format(mongo_host, mongo_port))
+        coll = conn.mydb.mycol
+
+        try:
+            with self.mock_gle() as mock:
+                yield coll.insert({'x': 42})
+                mock.assert_called_once_with('mydb', w=2, j=True)
+        finally:
+            yield coll.drop()
+            yield conn.disconnect()

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
 [testenv]
 deps = 
     coverage
+    mock
     pyopenssl
     pyparsing
     pycrypto

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -4,7 +4,6 @@
 
 import types
 
-import warnings
 import bson
 from bson import BSON, ObjectId
 from bson.code import Code

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -20,8 +20,9 @@ if 'reset' in inspect.getargspec(_check_command_response).args:
 class Database(object):
     __factory = None
 
-    def __init__(self, factory, database_name):
+    def __init__(self, factory, database_name, write_concern=None):
         self.__factory = factory
+        self.__write_concern = write_concern
         self._database_name = unicode(database_name)
 
     def __str__(self):
@@ -31,7 +32,7 @@ class Database(object):
         return "Database(%r, %r)" % (self.__factory, self._database_name,)
 
     def __call__(self, database_name):
-        return Database(self.__factory, database_name)
+        return Database(self.__factory, database_name, self.__write_concern)
 
     def __getitem__(self, collection_name):
         return Collection(self, collection_name)
@@ -46,6 +47,10 @@ class Database(object):
     @property
     def connection(self):
         return self.__factory
+
+    @property
+    def write_concern(self):
+        return self.__write_concern or self.__factory.write_concern
 
     @defer.inlineCallbacks
     def command(self, command, value=1, check=True, allowable_errors=None, **kwargs):

--- a/txmongo/protocol.py
+++ b/txmongo/protocol.py
@@ -378,18 +378,10 @@ class MongoProtocol(MongoServerProtocol, MongoClientProtocol):
         self.transport.loseConnection()
 
     @defer.inlineCallbacks
-    def get_last_error(self, db):
-        command = {"getlasterror": 1}
+    def get_last_error(self, db, **options):
+        command = SON([("getlasterror", 1)])
         db = "%s.$cmd" % db.split('.', 1)[0]
-        uri = self.factory.uri
-        if 'w' in uri["options"]:
-            command['w'] = int(uri["options"]['w'])
-        if "wtimeoutms" in uri["options"]:
-            command["wtimeout"] = int(uri["options"]["wtimeoutms"])
-        if "fsync" in uri["options"]:
-            command["fsync"] = bool(uri["options"]["fsync"])
-        if "journal" in uri["options"]:
-            command["journal"] = bool(uri["options"]["journal"])
+        command.update(options)
 
         query = Query(collection=db, query=command)
         reply = yield self.send_QUERY(query)

--- a/txmongo/write_concern.py
+++ b/txmongo/write_concern.py
@@ -1,0 +1,115 @@
+# Copyright 2014-2015 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tools for working with write concerns."""
+
+# TxMongo Note:
+# This module is a copy of pymongo/write_concern.py from PyMongo 3.0
+# Copied for PyMongo 2.8 support
+
+# PyMongo 2.8 doesn't have these variables, so we hardcode them
+# from bson.py3compat import integer_types, string_type
+integer_types = (int, long)
+string_type = basestring
+
+from pymongo.errors import ConfigurationError
+
+class WriteConcern(object):
+    """WriteConcern
+
+    :Parameters:
+        - `w`: (integer or string) Used with replication, write operations
+          will block until they have been replicated to the specified number
+          or tagged set of servers. `w=<integer>` always includes the replica
+          set primary (e.g. w=3 means write to the primary and wait until
+          replicated to **two** secondaries). **w=0 disables acknowledgement
+          of write operations and can not be used with other write concern
+          options.**
+        - `wtimeout`: (integer) Used in conjunction with `w`. Specify a value
+          in milliseconds to control how long to wait for write propagation
+          to complete. If replication does not complete in the given
+          timeframe, a timeout exception is raised.
+        - `j`: If ``True`` block until write operations have been committed
+          to the journal. Cannot be used in combination with `fsync`. Prior
+          to MongoDB 2.6 this option was ignored if the server was running
+          without journaling. Starting with MongoDB 2.6 write operations will
+          fail with an exception if this option is used when the server is
+          running without journaling.
+        - `fsync`: If ``True`` and the server is running without journaling,
+          blocks until the server has synced all data files to disk. If the
+          server is running with journaling, this acts the same as the `j`
+          option, blocking until write operations have been committed to the
+          journal. Cannot be used in combination with `j`.
+    """
+
+    __slots__ = ("__document", "__acknowledged")
+
+    def __init__(self, w=None, wtimeout=None, j=None, fsync=None):
+        self.__document = {}
+        self.__acknowledged = True
+
+        if wtimeout is not None:
+            if not isinstance(wtimeout, integer_types):
+                raise TypeError("wtimeout must be an integer")
+            self.__document["wtimeout"] = wtimeout
+
+        if j is not None:
+            if not isinstance(j, bool):
+                raise TypeError("j must be True or False")
+            self.__document["j"] = j
+
+        if fsync is not None:
+            if not isinstance(fsync, bool):
+                raise TypeError("fsync must be True or False")
+            if j and fsync:
+                raise ConfigurationError("Can't set both j "
+                                         "and fsync at the same time")
+            self.__document["fsync"] = fsync
+
+        if self.__document and w == 0:
+            raise ConfigurationError("Can not use w value "
+                                     "of 0 with other options")
+        if w is not None:
+            if isinstance(w, integer_types):
+                self.__acknowledged = w > 0
+            elif not isinstance(w, string_type):
+                raise TypeError("w must be an integer or string")
+            self.__document["w"] = w
+
+    @property
+    def document(self):
+        """The document representation of this write concern.
+
+        .. note::
+          :class:`WriteConcern` is immutable. Mutating the value of
+          :attr:`document` does not mutate this :class:`WriteConcern`.
+        """
+        return self.__document.copy()
+
+    @property
+    def acknowledged(self):
+        """If ``True`` write operations will wait for acknowledgement before
+        returning.
+        """
+        return self.__acknowledged
+
+    def __repr__(self):
+        return ("WriteConcern(%s)" % (
+            ", ".join("%s=%s" % kvt for kvt in self.document.items()),))
+
+    def __eq__(self, other):
+        return self.document == other.document
+
+    def __ne__(self, other):
+        return self.document != other.document


### PR DESCRIPTION
API closely resembles PyMongo

* `MongoConnection` and `ConnectionPool` now takes write-concern options as named args and as URI options (named args take precedence)

* You can set override write-concern for `Database` and `Collection` when creating them using constructors (`db = Database(conn, "dbname", write_concern=WriteConcern(...)`). In this case write concern is specified using instance of special `WriteConcern` class. It is copied to txmongo source tree from PyMongo 3.0 because it doesn't exist in 2.8.

* `insert`, `update`, `save` and `remove` now takes both `safe` argument and write-concern named arguments. Semantics is the same as in PyMongo 2.x:
    * named args (`w`, `wtimeout`, `j`, `fsync`) take precedence over `safe`
    * `safe=False` forces query to be unacknowledged
    * `safe=True` uses inherited (connection-, db- or collection-level) write-concern if it's acknowledged or forces simple acknowledged write-concern otherwise
    * if no arguments if specified inherited write-concern is used