### PR TITLE
Testing MONGODB-CR auth method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 
 before_install:
   - "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10"
-  - "echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list"
+  - "echo 'deb http://repo.mongodb.org/apt/ubuntu '$(lsb_release -sc)'/mongodb-org/3.0 multiverse' | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list"
   - "sudo apt-get update"
   - "sudo apt-get install mongodb-org-server"
   - "mongod --version"

--- a/tests/mongod.py
+++ b/tests/mongod.py
@@ -27,7 +27,7 @@ class Mongod(object):
     # so leaving this for now
     success_message = "waiting for connections on port"
 
-    def __init__(self, port=27017, auth=False, replset=None):
+    def __init__(self, port=27017, auth=False, replset=None, dbpath=None):
         self.__proc = None
         self.__notify_waiting = []
         self.__notify_stop = []
@@ -40,9 +40,14 @@ class Mongod(object):
         self.auth = auth
         self.replset = replset
 
-    def start(self):
-        self.__datadir = tempfile.mkdtemp()
+        if dbpath is None:
+            self.__datadir = tempfile.mkdtemp()
+            self.__rmdatadir = True
+        else:
+            self.__datadir = dbpath
+            self.__rmdatadir = False
 
+    def start(self):
         d = defer.Deferred()
         self.__notify_waiting.append(d)
 
@@ -94,7 +99,7 @@ class Mongod(object):
             else:
                 d.errback(reason)
 
-        if self.__datadir:
+        if self.__rmdatadir:
             shutil.rmtree(self.__datadir)
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -16,7 +16,6 @@
 import tempfile
 import shutil
 import txmongo
-from unittest import SkipTest
 from bson.son import SON
 from pymongo.errors import OperationFailure
 from twisted.trial import unittest
@@ -239,7 +238,7 @@ class TestMongoAuth(unittest.TestCase):
     @defer.inlineCallbacks
     def test_Explicit_SCRAM_SHA_1(self):
         if self.ismaster["maxWireVersion"] < 3:
-            raise SkipTest("This test is only applicable to MongoDB >= 3")
+            raise unittest.SkipTest("This test is only applicable to MongoDB >= 3")
 
         conn = self.__get_connection()
         try:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -150,7 +150,7 @@ class TestIndexInfo(unittest.TestCase):
         # dropDups was removed from MongoDB v3.0
         ismaster = yield self.db.command("ismaster")
         if ismaster["maxWireVersion"] >= 3:
-            raise unittest.SkipTest()
+            raise unittest.SkipTest("dropDups was removed from MongoDB 3")
 
         yield self.coll.drop()
         yield self.coll.insert([{'b': 1}, {'b': 1}])

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -259,7 +259,8 @@ class ConnectionPool(object):
 
         if self.__uri['database'] and self.__uri['username'] and self.__uri['password']:
             self.authenticate(self.__uri['database'], self.__uri['username'],
-                              self.__uri['password'])
+                              self.__uri['password'],
+                              self.__uri['options'].get('authmechanism', 'DEFAULT'))
 
         host, port = self.__uri['nodelist'][0]
 

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -100,7 +100,7 @@ class Database(object):
 
 
     @defer.inlineCallbacks
-    def authenticate(self, name, password):
+    def authenticate(self, name, password, mechanism="DEFAULT"):
         """
         Send an authentication command for this database.
         mostly stolen from pymongo
@@ -113,4 +113,4 @@ class Database(object):
         """
         Authenticating
         """
-        yield self.connection.authenticate(self, name, password)
+        yield self.connection.authenticate(self, name, password, mechanism)


### PR DESCRIPTION
`test_auth.py` expoits a hack to force MongoDB to use obsolete MONGODB-CR auth mechanism in order to get coverage of both SCRAM-SHA-1 and MONGODB-CR auth methods.

Travis environment changed to use MongoDB 3.0