### PR TITLE
?authMechanism URI option support backported from 15.1.0 to 15.0.0

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Release 15.0.1 (2015-11-13)
+---------------------------
+
+This is a maintenance update to outdated 15.0.0 release
+
+Features
+^^^^^^^^
+
+- Support for "?authMechanism=..." connection URI option
+
+
 Release 15.0 (2015-05-04)
 -------------------------
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,4 @@ wheel
 setuptools
 tox
 check-manifest
+mock

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
 [testenv]
 deps = 
     coverage
+    mock
     pyopenssl
     pyparsing
     pycrypto

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -238,7 +238,8 @@ class ConnectionPool(object):
 
         if self.__uri['database'] and self.__uri['username'] and self.__uri['password']:
             self.authenticate(self.__uri['database'], self.__uri['username'],
-                              self.__uri['password'])
+                              self.__uri['password'],
+                              self.__uri['options'].get('authmechanism', 'DEFAULT'))
 
         host, port = self.__uri['nodelist'][0]
 


### PR DESCRIPTION
I didn't cherry-picking because original tests for auth mechanisms in 15.1.0 require `db.command` which depend on PyMongo 3.0. So I added another testing code.

Is it ok that I inserted 15.0.1 in NEWS.rst?