### PR TITLE
Insert more than 1000 documents with insert_many

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -10,6 +10,11 @@ API Changes
 - ``insert_many()`` raises ``BulkWriteError`` instead ``WriteError``/``DuplicateKeyError`` to
   match PyMongo's behavior. This is also allows to extract multiple duplicate key errors from
   exception object when ``insert_many`` is used with ``ordered=False``.
+  
+Features
+^^^^^^^^
+
+- ``insert_many()`` is new able to insert more than 1000 documents or more than 16Mb of documents at once.
 
 Release 16.0.1 (2016-03-03)
 ---------------------------

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -594,6 +594,10 @@ class TestInsertOne(_SingleCollectionTest):
 
 class TestInsertMany(_SingleCollectionTest):
 
+    def setUp(self):
+        self.more_than_1k = [{"_id": i} for i in range(2016)]
+        return super(TestInsertMany, self).setUp()
+
     @defer.inlineCallbacks
     def test_InvalidArg(self):
         yield self.assertFailure(self.coll.insert_many({'x': 42}), TypeError)
@@ -617,43 +621,80 @@ class TestInsertMany(_SingleCollectionTest):
         self.assertEqual(result.acknowledged, False)
 
         docs = yield self.coll.find()
-        ids = set(doc["_id"] for doc in docs)
-
-        self.assertEqual(ids, set(result.inserted_ids))
+        self.assertEqual({doc["_id"] for doc in docs}, set(result.inserted_ids))
 
     @defer.inlineCallbacks
-    def test_OrderedAck(self):
-        docs = [{"_id": 1}, {"_id": 1, }, {"_id": 2}]
-        yield self.assertFailure(self.coll.insert_many(docs), BulkWriteError)
-
-        count = yield self.coll.count()
-        self.assertEqual(count, 1)
-
-    @defer.inlineCallbacks
-    def test_OrderedUnack(self):
-        docs = [{"_id": 1}, {"_id": 1, }, {"_id": 2}]
-        coll = self.coll.with_options(write_concern=WriteConcern(w=0))
-        yield coll.insert_many(docs)
-
-        count = yield self.coll.count()
-        self.assertEqual(count, 1)
+    def test_OrderedAck_Ok(self):
+        result = yield self.coll.insert_many(self.more_than_1k)
+        found = yield self.coll.find()
+        self.assertEqual(len(result.inserted_ids), len(self.more_than_1k))
+        self.assertEqual(len(found), len(self.more_than_1k))
+        self.assertEqual(set(result.inserted_ids), {doc["_id"] for doc in found})
 
     @defer.inlineCallbacks
-    def test_Unordered(self):
-        docs = [{"_id": 1}, {"_id": 1, }, {"_id": 2}]
-        yield self.assertFailure(self.coll.insert_many(docs, ordered=False), BulkWriteError)
-
-        count = yield self.coll.count()
-        self.assertEqual(count, 2)
+    def test_OrderedUnack_Ok(self):
+        w_0 = self.coll.with_options(write_concern=WriteConcern(w=0))
+        result = yield w_0.insert_many(self.more_than_1k)
+        found = yield self.coll.find()
+        self.assertEqual(len(result.inserted_ids), len(self.more_than_1k))
+        self.assertEqual(len(found), len(self.more_than_1k))
+        self.assertEqual(set(result.inserted_ids), {doc["_id"] for doc in found})
 
     @defer.inlineCallbacks
-    def test_UnorderedUnack(self):
-        docs = [{"_id": 1}, {"_id": 1, }, {"_id": 2}]
-        coll = self.coll.with_options(write_concern=WriteConcern(w=0))
-        yield coll.insert_many(docs, ordered=False)
+    def testOrderedAck_Fail(self):
+        self.more_than_1k[500] = self.more_than_1k[499]
+        with self.assertRaises(BulkWriteError) as raised:
+            yield self.coll.insert_many(self.more_than_1k)
+        self.assertEqual(raised.exception.details["nInserted"], 500)
+        self.assertEqual((yield self.coll.count()), 500)
+        self.assertEqual(len(raised.exception.details["writeErrors"]), 1)
+        self.assertEqual(raised.exception.details["writeErrors"][0]["index"], 500)
+        self.assertEqual(raised.exception.details["writeErrors"][0]["op"], {"_id": 499})
 
-        count = yield self.coll.count()
-        self.assertEqual(count, 2)
+    @defer.inlineCallbacks
+    def test_OrderedUnack_Fail(self):
+        self.more_than_1k[500] = self.more_than_1k[499]
+
+        w_0 = self.coll.with_options(write_concern=WriteConcern(w=0))
+        result = yield w_0.insert_many(self.more_than_1k)
+        self.assertEqual(len(result.inserted_ids), len(self.more_than_1k))
+        found = yield self.coll.find()
+        self.assertEqual(len(found), 500)
+        self.assertEqual({doc["_id"] for doc in found[:500]}, set(result.inserted_ids[:500]))
+
+    @defer.inlineCallbacks
+    def test_UnorderedAck_Fail(self):
+        self.more_than_1k[500] = self.more_than_1k[499]
+        with self.assertRaises(BulkWriteError) as raised:
+            yield self.coll.insert_many(self.more_than_1k, ordered=False)
+        self.assertEqual(raised.exception.details["nInserted"], len(self.more_than_1k) - 1)
+        self.assertEqual((yield self.coll.count()), len(self.more_than_1k) - 1)
+        self.assertEqual(len(raised.exception.details["writeErrors"]), 1)
+        self.assertEqual(raised.exception.details["writeErrors"][0]["index"], 500)
+        self.assertEqual(raised.exception.details["writeErrors"][0]["op"], {"_id": 499})
+
+    @defer.inlineCallbacks
+    def test_UnorderedUnack_Fail(self):
+        self.more_than_1k[500] = self.more_than_1k[499]
+
+        w_0 = self.coll.with_options(write_concern=WriteConcern(w=0))
+        result = yield w_0.insert_many(self.more_than_1k, ordered=False)
+        self.assertEqual(len(result.inserted_ids), len(self.more_than_1k))
+        found = yield self.coll.find()
+        self.assertEqual(len(found), len(self.more_than_1k) - 1)
+        self.assertEqual({doc["_id"] for doc in found}, set(result.inserted_ids) - {500})
+
+    @defer.inlineCallbacks
+    def test_MoreThan16Mb(self):
+        # 8mb x 5
+        mb40 = [{"_id": i, 'x': 'y'*(8*1024**2)} for i in range(5)]
+
+        result = yield self.coll.insert_many(mb40)
+        self.assertEqual(result.inserted_ids, list(range(5)))
+        found = yield self.coll.find()
+        self.assertEqual(len(found), 5)
+        total_size = sum(len(BSON.encode(doc)) for doc in found)
+        self.assertGreater(total_size, 40*1024**2)
 
 
 class TestUpdateOne(_SingleCollectionTest):

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -504,7 +504,7 @@ class Collection(object):
                 batch_result.addCallback(accumulate_response)
                 if ordered:
                     yield batch_result
-                    if has_errors:
+                    if has_errors():
                         if self.write_concern.acknowledged:
                             raise_error()
                         else:

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -16,6 +16,10 @@ from txmongo.database import Database
 from txmongo.protocol import MongoProtocol, Query
 
 
+DEFAULT_MAX_BSON_SIZE = 16 * 1024**2
+DEFAULT_MAX_WRITE_BATCH_SIZE = 1000
+
+
 _PRIMARY_READ_PREFERENCES = {ReadPreference.PRIMARY.mode, ReadPreference.PRIMARY_PREFERRED.mode}
 
 
@@ -109,9 +113,8 @@ class _Connection(ReconnectingClientFactory):
             raise ConfigurationError(msg)
 
         # Track max bson object size limit.
-        max_bson_size = config.get("maxBsonObjectSize")
-        if max_bson_size:
-            proto.max_bson_size = max_bson_size
+        proto.max_bson_size = config.get("maxBsonObjectSize", DEFAULT_MAX_BSON_SIZE)
+        proto.max_write_batch_size = config.get("maxWriteBatchSize", DEFAULT_MAX_WRITE_BATCH_SIZE)
 
         proto.set_wire_versions(config.get("minWireVersion", 0),
                                 config.get("maxWireVersion", 0))

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -16,7 +16,7 @@ from txmongo.database import Database
 from txmongo.protocol import MongoProtocol, Query
 
 
-DEFAULT_MAX_BSON_SIZE = 16 * 1024**2
+DEFAULT_MAX_BSON_SIZE = 16777216
 DEFAULT_MAX_WRITE_BATCH_SIZE = 1000
 
 


### PR DESCRIPTION
`insert_many` reimplemented to make it able to insert more than 1000 documents or more than 16Mb of documents at once. It now automatically splits documents into batches when reaching MongoDB limits (1000pcs or 16Mb).

Fixes #149 