### PR TITLE
Change GridFS's default chunkSize to 255kB

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -15,6 +15,7 @@ Features
 ^^^^^^^^
 
 - ``insert_many()`` is new able to insert more than 1000 documents or more than 16Mb of documents at once.
+- GridFS's default ``chunkSize`` changed to 255kB
 
 Release 16.0.1 (2016-03-03)
 ---------------------------

--- a/txmongo/_gridfs/grid_file.py
+++ b/txmongo/_gridfs/grid_file.py
@@ -26,7 +26,7 @@ from txmongo._gridfs.errors import CorruptGridFile
 from txmongo.collection import Collection
 
 """Default chunk size, in bytes."""
-DEFAULT_CHUNK_SIZE = 256 * 1024
+DEFAULT_CHUNK_SIZE = 255 * 1024
 
 
 def _create_property(field_name, docstring,
@@ -90,7 +90,7 @@ class GridIn(object):
             for the file
 
           - ``"chunkSize"`` or ``"chunk_size"``: size of each of the
-            chunks, in bytes (default: 256 kb)
+            chunks, in bytes (default: 255 kB)
 
         :Parameters:
           - `root_collection`: root collection to write to


### PR DESCRIPTION
I've also changed `kb` into `KB` (assuming it was a typo)