### PR TITLE
Fix GridFS.put yield on close

### DIFF
--- a/txmongo/_gridfs/__init__.py
+++ b/txmongo/_gridfs/__init__.py
@@ -97,7 +97,7 @@ class GridFS(object):
         try:
             yield grid_file.write(data)
         finally:
-            grid_file.close()
+            yield grid_file.close()
         defer.returnValue(grid_file._id)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Missing `yield` makes `GridFS.put` returns before the file is actually written in GridFS