### PR TITLE
GridFS.get raises NoFile if file is not found

### DIFF
--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -179,8 +179,8 @@ class TestGridFsObjects(unittest.TestCase):
         """ Tests gridfs objects """
         conn = yield txmongo.MongoConnection(mongo_host, mongo_port)
         db = conn.test
-        db.fs.files.remove({})  # drop all objects there first
-        db.fs.chunks.remove({})
+        yield db.fs.files.remove({})  # drop all objects there first
+        yield db.fs.chunks.remove({})
         self.assertRaises(TypeError, GridFS, None)
         _ = GridFS(db)  # Default collection
         self.assertRaises(TypeError, GridIn, None)
@@ -239,8 +239,8 @@ class TestGridFsObjects(unittest.TestCase):
         """ Tests gridfs objects """
         conn = yield txmongo.MongoConnection(mongo_host, mongo_port)
         db = conn.test
-        db.fs.files.remove({})  # drop all objects there first
-        db.fs.chunks.remove({})
+        yield db.fs.files.remove({})  # drop all objects there first
+        yield db.fs.chunks.remove({})
         gfs = GridFS(db)  # Default collection
         yield gfs.delete(u"test")
 
@@ -248,7 +248,7 @@ class TestGridFsObjects(unittest.TestCase):
         yield conn.disconnect()
         conn = yield txmongo.MongoConnection(mongo_host, mongo_port)
         db = conn.test
-        db.fs.files.remove({})  # drop all objects there first
+        yield db.fs.files.remove({})  # drop all objects there first
         gfs = GridFS(db)  # Default collection
         _ = yield gfs.put(b"0xDEADBEEF", filename="test_2", contentType="text/plain",
                           chunk_size=65536)
@@ -258,7 +258,9 @@ class TestGridFsObjects(unittest.TestCase):
         conn = yield txmongo.MongoConnection(mongo_host, mongo_port)
         db = conn.test
         gfs = GridFS(db)  # Default collection
-        _ = yield gfs.get("test_3")
+        # Missing file raises error
+        with self.assertRaises(NoFile):
+            _ = yield gfs.get("test_3")
         # disconnect
         yield conn.disconnect()
 
@@ -267,8 +269,8 @@ class TestGridFsObjects(unittest.TestCase):
         """ Tests gridfs iterator """
         conn = yield txmongo.MongoConnection(mongo_host, mongo_port)
         db = conn.test
-        db.fs.files.remove({})  # drop all objects there first
-        db.fs.chunks.remove({})
+        yield db.fs.files.remove({})  # drop all objects there first
+        yield db.fs.chunks.remove({})
         gfs = GridFS(db)  # Default collection
         new_file = gfs.new_file(filename="testName", contentType="text/plain", length=1048576,
                                 chunk_size=4096)
@@ -300,7 +302,7 @@ class TestGridFsObjects(unittest.TestCase):
         """ Tests gridfs operations """
         conn = yield txmongo.MongoConnection(mongo_host, mongo_port)
         db = conn.test
-        db.fs.files.remove({})  # Drop files first TODO: iterate through files and delete them
+        yield db.fs.files.remove({})  # Drop files first TODO: iterate through files and delete them
 
         # Don't forget to disconnect
         self.addCleanup(self._disconnect, conn)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -178,7 +178,10 @@ class TestGridFsObjects(unittest.TestCase):
         """
         Drop the default gridfs instance (i.e. ``fs``) associate to this database
         """
-        return defer.gatherResults([db.fs.files.remove({}), db.fs.chunks.remove({})])
+        return defer.gatherResults([
+            db.drop_collection('fs.files'),
+            db.drop_collection('fs.chunks')
+        ])
 
     @defer.inlineCallbacks
     def test_GridFileObjects(self):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -266,8 +266,7 @@ class TestGridFsObjects(unittest.TestCase):
         db = conn.test
         gfs = GridFS(db)  # Default collection
         # Missing file raises error
-        with self.assertRaises(NoFile):
-            _ = yield gfs.get("test_3")
+        yield self.assertFailure(gfs.get("test_3"), NoFile)
         # disconnect
         yield conn.disconnect()
 

--- a/txmongo/_gridfs/__init__.py
+++ b/txmongo/_gridfs/__init__.py
@@ -55,6 +55,7 @@ class GridFS(object):
         self.__chunks.create_index(filter.sort(ASCENDING("files_id") + ASCENDING("n")),
                                    unique=True)
 
+
     def new_file(self, **kwargs):
         """Create a new file in GridFS.
 
@@ -114,6 +115,8 @@ class GridFS(object):
         """
 
         doc = yield self.__collection.files.find_one({"_id": file_id})
+        if doc is None:
+            raise NoFile("TxMongo: no file in gridfs with _id {0}".format(repr(file_id)))
 
         defer.returnValue(GridOut(self.__collection, doc))
 

--- a/txmongo/_gridfs/__init__.py
+++ b/txmongo/_gridfs/__init__.py
@@ -98,7 +98,7 @@ class GridFS(object):
         try:
             yield grid_file.write(data)
         finally:
-            grid_file.close()
+            yield grid_file.close()
         defer.returnValue(grid_file._id)
 
     @defer.inlineCallbacks


### PR DESCRIPTION
As talked in #160 

I've also corrected missing `yield` in `db.fs.files.remove({})` which lead to concurrency errors