### PR TITLE
GridFS ensure indexes is done without yielding

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -17,6 +17,9 @@ Features
 
 - ``insert_many()`` is now able to insert more than 1000 documents and more than 16Mb of documents at once.
 - GridFS's default ``chunkSize`` changed to 255kB, to avoid the overhead with usePowerOf2Sizes option.
+- Add ``GridFS.get_indexes_created_defer`` to obtain a defer on the creation of the current
+  GridFS instance's indexes
+- GridFS create indexes for the ``files`` collection in addition to the ``chunks`` one
 
 Release 16.0.1 (2016-03-03)
 ---------------------------

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -17,7 +17,7 @@ Features
 
 - ``insert_many()`` is now able to insert more than 1000 documents and more than 16Mb of documents at once.
 - GridFS's default ``chunkSize`` changed to 255kB, to avoid the overhead with usePowerOf2Sizes option.
-- Add ``GridFS.get_indexes_created_defer`` to obtain a defer on the creation of the current
+- Add ``GridFS.indexes_created`` to obtain a defer on the creation of the current
   GridFS instance's indexes
 - GridFS create indexes for the ``files`` collection in addition to the ``chunks`` one
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -367,9 +367,8 @@ class TestGridFsObjects(unittest.TestCase):
         gfs = GridFS(db)
 
         # Multiple calls should return multiple defer not to mix between them
-        self.assertNotEqual(gfs.get_indexes_created_defer(),
-                            gfs.get_indexes_created_defer())
+        self.assertNotEqual(gfs.indexes_created(), gfs.indexes_created())
 
-        yield gfs.get_indexes_created_defer()
+        yield gfs.indexes_created()
 
         yield conn.disconnect()

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -355,3 +355,21 @@ class TestGridFsObjects(unittest.TestCase):
                          "`optest` is the only expected file and we received %s" % listed_files)
 
         yield gfs.delete(_id)
+
+    @defer.inlineCallbacks
+    def test_GridFsIndexesCreation(self):
+        """ Tests gridfs indexes creation"""
+        conn = yield txmongo.MongoConnection(mongo_host, mongo_port)
+        db = conn.test
+        yield self._drop_gridfs(db)
+
+        # Create a new GridFS instance should trigger indexes creation
+        gfs = GridFS(db)
+
+        # Multiple calls should return multiple defer not to mix between them
+        self.assertNotEqual(gfs.get_indexes_created_defer(),
+                            gfs.get_indexes_created_defer())
+
+        yield gfs.get_indexes_created_defer()
+
+        yield conn.disconnect()

--- a/txmongo/_gridfs/__init__.py
+++ b/txmongo/_gridfs/__init__.py
@@ -52,9 +52,19 @@ class GridFS(object):
         self.__collection = database[collection]
         self.__files = self.__collection.files
         self.__chunks = self.__collection.chunks
-        self.__chunks.create_index(filter.sort(ASCENDING("files_id") + ASCENDING("n")),
-                                   unique=True)
+        self.__indexes_created_defer = defer.DeferredList([
+            self.__files.create_index(
+                filter.sort(ASCENDING("filesname") + ASCENDING("uploadDate"))),
+            self.__chunks.create_index(
+                filter.sort(ASCENDING("files_id") + ASCENDING("n")), unique=True)
+        ])
 
+    def get_indexes_created_defer(self):
+        """Returns a defer on
+        """
+        d = defer.Deferred()
+        self.__indexes_created_defer.chainDeferred(d)
+        return d
 
     def new_file(self, **kwargs):
         """Create a new file in GridFS.

--- a/txmongo/_gridfs/__init__.py
+++ b/txmongo/_gridfs/__init__.py
@@ -42,6 +42,13 @@ class GridFS(object):
           - `database`: database to use
           - `collection` (optional): root collection to use
 
+        .. note::
+
+            Instantiating a GridFS object will implicitly create it indexes.
+            This could leads to errors if the underlaying connection is closed
+            before the indexes creation request has returned. To avoid this you
+            should use the defer returned by :meth:`GridFS.indexes_created`.
+
         .. versionadded:: 1.6
            The `collection` parameter.
         """
@@ -59,8 +66,8 @@ class GridFS(object):
                 filter.sort(ASCENDING("files_id") + ASCENDING("n")), unique=True)
         ])
 
-    def get_indexes_created_defer(self):
-        """Returns a defer on
+    def indexes_created(self):
+        """Returns a defer on the creation of this GridFS instance's indexes
         """
         d = defer.Deferred()
         self.__indexes_created_defer.chainDeferred(d)


### PR DESCRIPTION
Correction for #164
This PR is based on PR #163 (needed to make the unit tests work), only commit 059355c1a8cb0438c4e46121820fc21895e6fc2c should be considered