### PR TITLE
fields parameter removed for count()

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -10,7 +10,8 @@ API Changes
 - ``insert_many()`` raises ``BulkWriteError`` instead ``WriteError``/``DuplicateKeyError`` to
   match PyMongo's behavior. This is also allows to extract multiple duplicate key errors from
   exception object when ``insert_many`` is used with ``ordered=False``.
-  
+- ``fields`` parameter removed for ``Collection.count()``.
+
 Features
 ^^^^^^^^
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1057,3 +1057,23 @@ class TestFindOneAndUpdate(_SingleCollectionTest):
         doc = yield self.coll.find_one_and_update({'x': 10}, {"$set": {'y': 15}},
                                                   return_document=ReturnDocument.AFTER)
         self.assertEqual(doc['y'], 15)
+
+
+class TestCount(_SingleCollectionTest):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        yield super(TestCount, self).setUp()
+        yield self.coll.insert_many([{'x': 10}, {'x': 20}, {'x': 30}])
+
+    @defer.inlineCallbacks
+    def test_count(self):
+        self.assertEqual((yield self.coll.count()), 3)
+        self.assertEqual((yield self.coll.count({'x': 20})), 1)
+        self.assertEqual((yield self.coll.count({'x': {"$gt": 15}})), 2)
+
+        self.assertEqual((yield self.db.non_existing.count()), 0)
+
+        # This should fail with 'bad hint' if hint parameter works correctly
+        yield self.assertFailure(self.coll.count(hint=qf.sort(qf.ASCENDING('x'))),
+                                 OperationFailure)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -121,13 +121,10 @@ class TestMongoQueries(_SingleCollectionTest):
     def test_SpecifiedFields(self):
         yield self.coll.insert([dict((k, v) for k in "abcdefg") for v in range(5)], safe=True)
         res = yield self.coll.find(fields={'a': 1, 'c': 1})
-        yield self.coll.count(fields={'a': 1, 'c': 1})
         self.assertTrue(all(x in ['a', 'c', "_id"] for x in res[0].keys()))
         res = yield self.coll.find(fields=['a', 'c'])
-        yield self.coll.count(fields=['a', 'c'])
         self.assertTrue(all(x in ['a', 'c', "_id"] for x in res[0].keys()))
         res = yield self.coll.find(fields=[])
-        yield self.coll.count(fields=[])
         self.assertTrue(all(x in ["_id"] for x in res[0].keys()))
         yield self.assertFailure(self.coll.find({}, fields=[1]), TypeError)
 

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1073,7 +1073,3 @@ class TestCount(_SingleCollectionTest):
         self.assertEqual((yield self.coll.count({'x': {"$gt": 15}})), 2)
 
         self.assertEqual((yield self.db.non_existing.count()), 0)
-
-        # This should fail with 'bad hint' if hint parameter works correctly
-        yield self.assertFailure(self.coll.count(hint=qf.sort(qf.ASCENDING('x'))),
-                                 OperationFailure)

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -266,12 +266,9 @@ class Collection(object):
 
     @timeout
     @defer.inlineCallbacks
-    def count(self, spec=None, fields=None, **kwargs):
-        fields = self._normalize_fields_projection(fields)
-
+    def count(self, spec=None, **kwargs):
         result = yield self._database.command("count", self._collection_name,
-                                              query=spec or SON(),
-                                              fields=fields, **kwargs)
+                                              query=spec or SON(), **kwargs)
         defer.returnValue(int(result["n"]))
 
     @timeout


### PR DESCRIPTION
`fields` projection parameter seems to be completely pointless for `count()`

I don't think removing it could break any existing code.

Also added distinct test case for `count()`