### PR TITLE
Better docs

### DIFF
--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -30,10 +30,14 @@ from twisted.python.compat import unicode, comparable
 class Collection(object):
     """Creates new :class:`Collection` object
 
-    :Parameters:
-      - `database`: the :class:`Database` instance to get collection from
-      - `name`: the name of the collection to get
-      - `write_concern` (optional): An instance of :class:`pymongo.write_concern.WriteConcern`.
+    :param database:
+        the :class:`Database` instance to get collection from
+
+    :param name:
+        the name of the collection to get
+
+    :param write_concern:
+        An instance of :class:`pymongo.write_concern.WriteConcern`.
         If ``None``, ``database.write_concern`` is used.
     """
 
@@ -116,9 +120,8 @@ class Collection(object):
     def with_options(self, **kwargs):
         """Get a clone of collection changing the specified settings.
 
-        :Keyword parameters:
-          - `write_concern`: new :class:`~pymongo.write_concern.WriteConcern`
-            to use.
+        :param write_concern: *(keyword only)*
+            new :class:`~pymongo.write_concern.WriteConcern` to use.
         """
         # PyMongo's method gets several positional arguments. We support
         # only write_concern for now which is the 3rd positional argument.
@@ -161,8 +164,9 @@ class Collection(object):
     def options(self, **kwargs):
         """Get the options set on this collection.
 
-        Returns :class:`Deferred` that called back with dictionary of options
-        and their values.
+        :returns:
+            :class:`Deferred` that called back with dictionary of options
+            and their values.
 
         *This method only works with MongoDB 2.x*
         """
@@ -188,36 +192,41 @@ class Collection(object):
         Ordering, indexing hints and other query parameters can be set with
         `filter` argument. See :mod:`txmongo.filter` for details.
 
-        :Parameters:
-          - `skip`: the number of documents to omit from the start of the
-            result set.
-          - `limit`: the maximum number of documents to return. All documents
-            are returned when `limit` is zero.
-          - `fields`: a list of field names that should be returned for each
-            document in the result set or a dict specifying field names to
-            include or exclude. If `fields` is a list ``_id`` fields will
-            always be returned. Use a dict form to exclude fields:
-            ``fields={"_id": False}``.
-          - `as_class` (keyword only): if not ``None``, returned documents will
-            be converted to type specified. For example, you can use
-            ``as_class=collections.OrderedDict`` or ``as_class=bson.SON`` when
-            field ordering in documents is important.
+        :param skip:
+            the number of documents to omit from the start of the result set.
 
-        Returns an instance of :class:`Deferred` that called back with one of:
-          - if `cursor` is ``False`` (the default) --- all documents found
-          - if `cursor` is ``True`` --- tuple of ``(docs, dfr)``, where ``docs``
-            is a partial result, returned by MongoDB in a first batch and
-            ``dfr`` is a :class:`Deferred` that fires with next ``(docs, dfr)``.
-            Last result will be ``([], None)``. Using this mode you can iterate
-            over the result set with code like that:
-            ::
-                @defer.inlineCallbacks
-                def query():
-                    docs, dfr = yield coll.find(query, cursor=True)
-                    while docs:
-                        for doc in docs:
-                            do_something(doc)
-                        docs, dfr = yield dfr
+        :param limit:
+            the maximum number of documents to return. All documents are
+            returned when `limit` is zero.
+
+        :param fields:
+            a list of field names that should be returned for each document
+            in the result set or a dict specifying field names to include or
+            exclude. If `fields` is a list ``_id`` fields will always be
+            returned. Use a dict form to exclude fields:
+            ``fields={"_id": False}``.
+
+        :param as_class: *(keyword only)*
+            if not ``None``, returned documents will be converted to type
+            specified. For example, you can use ``as_class=collections.OrderedDict``
+            or ``as_class=bson.SON`` when field ordering in documents is important.
+
+        :returns: an instance of :class:`Deferred` that called back with one of:
+
+            - if `cursor` is ``False`` (the default) --- all documents found
+            - if `cursor` is ``True`` --- tuple of ``(docs, dfr)``, where
+              ``docs`` is a partial result, returned by MongoDB in a first
+              batch and ``dfr`` is a :class:`Deferred` that fires with next
+              ``(docs, dfr)``. Last result will be ``([], None)``. Using this
+              mode you can iterate over the result set with code like that:
+              ::
+                  @defer.inlineCallbacks
+                  def query():
+                      docs, dfr = yield coll.find(query, cursor=True)
+                      while docs:
+                          for doc in docs:
+                              do_something(doc)
+                          docs, dfr = yield dfr
         """
         docs, dfr = yield self.find_with_cursor(spec=spec, skip=skip, limit=limit,
                                                 fields=fields, filter=filter, **kwargs)
@@ -335,8 +344,9 @@ class Collection(object):
         All arguments to :meth:`find()` are also valid for :meth:`find_one()`,
         although `limit` will be ignored.
 
-        Returns a :class:`Deferred` that called back with single document
-        or ``None`` if no matching documents is found.
+        :returns:
+            a :class:`Deferred` that called back with single document
+            or ``None`` if no matching documents is found.
         """
         if isinstance(spec, ObjectId):
             spec = {"_id": spec}
@@ -351,11 +361,15 @@ class Collection(object):
     def count(self, spec=None, **kwargs):
         """Get the number of documents in this collection.
 
-        `spec` argument is a query document that selects which documents to
-        count in the collection.
+        :param spec:
+            argument is a query document that selects which documents to
+            count in the collection.
 
-        Returns a :class:`Deferred` that called back with a number of
-        documents matching the criteria.
+        :param hint: *(keyword only)*
+            :class:`~txmongo.filter.hint` instance specifying index to use.
+
+        :returns: a :class:`Deferred` that called back with a number of
+                  documents matching the criteria.
         """
         result = yield self._database.command("count", self._collection_name,
                                               query=spec or SON(), **kwargs)

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -680,6 +680,41 @@ class Collection(object):
     @timeout
     @defer.inlineCallbacks
     def update(self, spec, document, upsert=False, multi=False, safe=None, flags=0, **kwargs):
+        """Update document(s) in this collection
+
+        *Please consider using new-style* :meth:`update_one()`, :meth:`update_many()`
+        and :meth:`replace_one()` *methods instead.*
+
+        :raises TypeError:
+            if `spec` or `document` are not instances of `dict`
+            or `upsert` is not an instance of `bool`.
+
+        :param spec:
+            query document that selects documents to be updated
+
+        :param document:
+            update document to be used for updating or upserting. See
+            `MongoDB Update docs
+            <https://docs.mongodb.org/manual/tutorial/modify-documents/>`_
+            for the format of this document and allowed operators.
+
+        :param upsert:
+            perform an upsert if ``True``
+
+        :param multi:
+            update all documents that match `spec`, rather than just the first
+            matching document. The default value is ``False``.
+
+        :param safe:
+            ``True`` or ``False`` forces usage of respectively acknowledged or
+            unacknowledged Write Concern. If ``None``, :attr:`write_concern` is
+            used.
+
+        :returns:
+            :class:`Deferred` that is called back when request is sent to
+            MongoDB or confirmed by MongoDB (depending on selected Write Concern).
+        """
+
         if not isinstance(spec, dict):
             raise TypeError("TxMongo: spec must be an instance of dict.")
         if not isinstance(document, dict):

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -769,6 +769,31 @@ class Collection(object):
     @timeout
     @defer.inlineCallbacks
     def update_one(self, filter, update, upsert=False, **kwargs):
+        """Update a single document matching the filter.
+
+        :raises ValueError:
+            if `update` document is empty.
+
+        :raises ValueError:
+            if `update` document has any fields that don't start with `$` sign.
+            This method only allows *modification* of document (with `$set`,
+            `$inc`, etc.), not *replacing* it. For replacing use
+            :meth:`replace_one()` instead.
+
+        :param filter:
+            A query that matches the document to update.
+
+        :param update:
+            update document to be used for updating or upserting. See `MongoDB
+            Update docs <https://docs.mongodb.org/manual/tutorial/modify-documents/>`_
+            for allowed operators.
+
+        :param upsert:
+            If ``True``, perform an insert if no documents match the `filter`.
+
+        :returns:
+            deferred instance of :class:`pymongo.results.UpdateResult`.
+        """
         validate_ok_for_update(update)
 
         raw_response = yield self._update(filter, update, upsert, multi=False, **kwargs)
@@ -777,6 +802,31 @@ class Collection(object):
     @timeout
     @defer.inlineCallbacks
     def update_many(self, filter, update, upsert=False, **kwargs):
+        """Update one or more documents that match the filter.
+
+        :raises ValueError:
+            if `update` document is empty.
+
+        :raises ValueError:
+            if `update` document has fields that don't start with `$` sign.
+            This method only allows *modification* of document (with `$set`,
+            `$inc`, etc.), not *replacing* it. For replacing use
+            :meth:`replace_one()` instead.
+
+        :param filter:
+            A query that matches the documents to update.
+
+        :param update:
+            update document to be used for updating or upserting. See `MongoDB
+            Update docs <https://docs.mongodb.org/manual/tutorial/modify-documents/>`_
+            for allowed operators.
+
+        :param upsert:
+            If ``True``, perform an insert if no documents match the `filter`.
+
+        :returns:
+            deferred instance of :class:`pymongo.results.UpdateResult`.
+        """
         validate_ok_for_update(update)
 
         raw_response = yield self._update(filter, update, upsert, multi=True, **kwargs)
@@ -785,6 +835,28 @@ class Collection(object):
     @timeout
     @defer.inlineCallbacks
     def replace_one(self, filter, replacement, upsert=False, **kwargs):
+        """Replace a single document matching the filter.
+
+        :raises ValueError:
+            if `update` document is empty
+
+        :raises ValueError:
+            if `update` document has fields that starts with `$` sign.
+            This method only allows *replacing* document completely. Use
+            :meth:`update_one()` for modifying existing document.
+
+        :param filter:
+            A query that matches the document to replace.
+
+        :param replacement:
+            The new document to replace with.
+
+        :param upsert:
+            If ``True``, perform an insert if no documents match the filter.
+
+        :returns:
+            deferred instance of :class:`pymongo.results.UpdateResult`.
+        """
         validate_ok_for_replace(replacement)
 
         raw_response = yield self._update(filter, replacement, upsert, multi=False, **kwargs)

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -248,13 +248,10 @@ class Collection(object):
 
     @timeout
     def find_with_cursor(self, spec=None, skip=0, limit=0, fields=None, filter=None, **kwargs):
-        """ find method that uses the cursor to only return a block of
-        results at a time.
-        Arguments are the same as with find()
-        returns deferred that results in a tuple: (docs, deferred) where
-        docs are the current page of results and deferred results in the next
-        tuple. When the cursor is exhausted, it will return the tuple
-        ([], None)
+        """Find documents in a collection and return them in one batch at a time
+
+        This methid is equivalent of :meth:`find()` with `cursor=True`.
+        See :meth:`find()` for description of parameters and return value.
         """
         if spec is None:
             spec = SON()
@@ -333,6 +330,14 @@ class Collection(object):
     @timeout
     @defer.inlineCallbacks
     def find_one(self, spec=None, fields=None, **kwargs):
+        """Get a single document from the collection.
+
+        All arguments to :meth:`find()` are also valid for :meth:`find_one()`,
+        although `limit` will be ignored.
+
+        Returns a :class:`Deferred` that called back with single document
+        or ``None`` if no matching documents is found.
+        """
         if isinstance(spec, ObjectId):
             spec = {"_id": spec}
 
@@ -344,6 +349,14 @@ class Collection(object):
     @timeout
     @defer.inlineCallbacks
     def count(self, spec=None, **kwargs):
+        """Get the number of documents in this collection.
+
+        `spec` argument is a query document that selects which documents to
+        count in the collection.
+
+        Returns a :class:`Deferred` that called back with a number of
+        documents matching the criteria.
+        """
         result = yield self._database.command("count", self._collection_name,
                                               query=spec or SON(), **kwargs)
         defer.returnValue(int(result["n"]))


### PR DESCRIPTION
I've initially planned to make a PR when I finish writing docs for all `Collection` and `Database` methods. But all these docstrings need proof-reading and fact-checking. And writing and proof-reading can be done in parallel if I release early.

Texts are partly stolen from PyMongo, partly written from scratch. Please excuse and fix my poor English. 