### PR TITLE
default watchdog timeouts increased

### DIFF
--- a/tests/test_replicaset.py
+++ b/tests/test_replicaset.py
@@ -279,7 +279,8 @@ class TestReplicaSet(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_StaleConnection(self):
-        conn = MongoConnection("localhost", self.ports[0])
+        conn = MongoConnection("localhost", self.ports[0],
+                               watchdog_interval=10, watchdog_timeout=5)
         try:
             yield conn.db.coll.count()
             self.__mongod[0].kill(signal.SIGSTOP)

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -254,7 +254,7 @@ class ConnectionPool(object):
     __wc_possible_options = {'w', "wtimeout", 'j', "fsync"}
 
     def __init__(self, uri="mongodb://127.0.0.1:27017", pool_size=1, ssl_context_factory=None,
-                 watchdog_interval=15, watchdog_timeout=5, **kwargs):
+                 watchdog_interval=30, watchdog_timeout=120, **kwargs):
         assert isinstance(uri, StringType)
         assert isinstance(pool_size, int)
         assert pool_size >= 1


### PR DESCRIPTION
It turns out that low default values prevents us from issuing long-running queries