### PR TITLE
Fixed handling of connection errors in bulk_write

### DIFF
--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -1171,6 +1171,9 @@ class Collection(object):
                     all_responses.append(batch_result)
 
         if self.write_concern.acknowledged and not ordered:
-            yield defer.DeferredList(all_responses)
+            try:
+                yield defer.gatherResults(all_responses, consumeErrors=True)
+            except defer.FirstError as e:
+                e.subFailure.raiseException()
 
         defer.returnValue(results)


### PR DESCRIPTION
`bulk_write()` was not propagating exceptions (`AutoReconnect`, for example) when used with `ordered=False`