### PR TITLE
support for codec_options

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -10,6 +10,9 @@ Features
 - ``Collection.bulk_write()`` that maches behavior of corresponding PyMongo's method. It accepts
   an iterable of ``InsertOne``, ``UpdateOne``, ... from ``pymongo.operations``, packs them into
   batches and returns aggregated response from MongoDB.
+- ``codec_options`` properties for ``ConnectionPool``, ``Database`` and ``Collection``.
+  ``Collection.with_options(codec_options=CodecOptions(document_class=...))`` is now preferred
+  over ``Collection.find(..., as_class=...)``.
 
 Release 16.1.0 (2016-06-15)
 ---------------------------

--- a/tests/test_codec_options.py
+++ b/tests/test_codec_options.py
@@ -34,7 +34,7 @@ class TestCodecOptions(unittest.TestCase):
         self.conn = MongoConnection(mongo_host, mongo_port)
         self.db = self.conn.db
         self.coll = self.db.coll
-        yield self.coll.insert_one({'x': 42, 'y': datetime.datetime.now(), 'z': b'a\xffb'})
+        yield self.coll.insert_one({'x': 42, 'y': datetime.datetime.now()})
 
     @defer.inlineCallbacks
     def tearDown(self):

--- a/tests/test_codec_options.py
+++ b/tests/test_codec_options.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+# Copyright 2015 Ilya Skriblovsky <ilyaskriblovsky@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division
+
+import datetime
+from bson import SON
+from bson.codec_options import CodecOptions
+from twisted.trial import unittest
+from twisted.internet import defer
+from txmongo.connection import MongoConnection
+from txmongo.database import Database
+
+mongo_host = "localhost"
+mongo_port = 27017
+
+
+class TestCodecOptions(unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.conn = MongoConnection(mongo_host, mongo_port)
+        self.db = self.conn.db
+        self.coll = self.db.coll
+        yield self.coll.insert_one({'x': 42, 'y': datetime.datetime.now(), 'z': b'a\xffb'})
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.coll.drop()
+        yield self.conn.disconnect()
+
+    @defer.inlineCallbacks
+    def test_Levels(self):
+        as_son = CodecOptions(document_class=SON)
+
+        doc = yield self.coll.find_one()
+        self.assertIsInstance(doc, dict)
+
+        try:
+            conn = MongoConnection(mongo_host, mongo_port, codec_options=as_son)
+            doc = yield conn.db.coll.find_one()
+            self.assertIsInstance(doc, SON)
+        finally:
+            yield conn.disconnect()
+
+        doc = yield Database(self.conn, "db", codec_options=as_son).coll.find_one()
+        self.assertIsInstance(doc, SON)
+
+        doc = yield self.coll.with_options(codec_options=as_son).find_one()
+        self.assertIsInstance(doc, SON)
+
+    @defer.inlineCallbacks
+    def test_TzAware(self):
+        doc = yield self.coll.find_one()
+        self.assertIsNone(doc['y'].tzinfo, None)
+
+        tz_aware = CodecOptions(tz_aware=True)
+        doc = yield self.coll.with_options(codec_options=tz_aware).find_one()
+        self.assertIsNotNone(doc['y'].tzinfo, None)

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division
 
+from bson.codec_options import DEFAULT_CODEC_OPTIONS
 from pymongo.errors import AutoReconnect, ConfigurationError, OperationFailure
 from pymongo.uri_parser import parse_uri
 from pymongo.read_preferences import ReadPreference
@@ -271,6 +272,8 @@ class ConnectionPool(object):
         wc_options = dict((k, v) for k, v in wc_options.items() if k in self.__wc_possible_options)
         self.__write_concern = WriteConcern(**wc_options)
 
+        self.__codec_options = kwargs.get('codec_options', DEFAULT_CODEC_OPTIONS)
+
         retry_delay = kwargs.get('retry_delay', 1.0)
         max_delay = kwargs.get('max_delay', 60.0)
         self.__pool_size = pool_size
@@ -297,6 +300,10 @@ class ConnectionPool(object):
     @property
     def write_concern(self):
         return self.__write_concern
+
+    @property
+    def codec_options(self):
+        return self.__codec_options
 
     def getprotocols(self):
         return self.__pool

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -13,9 +13,11 @@ from txmongo.utils import timeout
 class Database(object):
     __factory = None
 
-    def __init__(self, factory, database_name, write_concern=None):
+    def __init__(self, factory, database_name, write_concern=None,
+                 codec_options=None):
         self.__factory = factory
         self.__write_concern = write_concern
+        self.__codec_options = codec_options
         self._database_name = unicode(database_name)
 
     def __str__(self):
@@ -25,7 +27,8 @@ class Database(object):
         return "Database(%r, %r)" % (self.__factory, self._database_name,)
 
     def __call__(self, database_name):
-        return Database(self.__factory, database_name, self.__write_concern)
+        return Database(self.__factory, database_name, self.__write_concern,
+                        self.__codec_options)
 
     def __getitem__(self, collection_name):
         return Collection(self, collection_name)
@@ -44,6 +47,10 @@ class Database(object):
     @property
     def write_concern(self):
         return self.__write_concern or self.__factory.write_concern
+
+    @property
+    def codec_options(self):
+        return self.__codec_options or self.__factory.codec_options
 
     @timeout
     @defer.inlineCallbacks


### PR DESCRIPTION
We have used `pymongo.bulk._Bulk` internal class to implement bulk ops. But since PyMongo 3.3.0 that was released a week ago, this class assumes that `Collection` has proper support of codec options.

This patch adds `codec_options` to `ConnectionPool`, `Database` and `Collection` classes and `codec_options` kwarg to `Collection.with_options()`. This fixes our test suite that is failing since PyMongo 3.3 release.

I've also added notice in NEWS.rst that `Collection.with_options` should be preferred now instead of `as_class` kwags to `find`. PyMongo had dropped `as_class` kwags in 3.0.