### PR TITLE
fixing tests against twisted-trunk

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ deps =
     tw153: Twisted==15.3
     tw150: Twisted==15.0
     tw140: Twisted==14.0
+setenv =
+    PYTHONPATH = {toxinidir}
 commands =
     {envpython} --version
     trial --version


### PR DESCRIPTION
Twisted team changed something in either Trial or `twisted.python.reflect` and now our `trial tests` says `can't find module "tests"`. I'm not sure if it is a bug in Twisted and whether it will be fixed, but lets fix this on our side for now.