### PR TITLE
Various tests fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,31 @@ python: 2.7
 #    - pypy
 
 env:
+    - TOX_ENV=py27-tw140
+    - TOX_ENV=py27-tw150
+    - TOX_ENV=py27-tw155
+    - TOX_ENV=py27-tw160
+    - TOX_ENV=py27-tw163
     - TOX_ENV=py27-twlatest
     - TOX_ENV=py27-twtrunk
-    - TOX_ENV=py27-tw154
-    - TOX_ENV=py27-tw153
-    - TOX_ENV=py27-tw150
-    - TOX_ENV=py27-tw140
+    - TOX_ENV=py33-tw160
+    - TOX_ENV=py33-tw163
+    - TOX_ENV=py33-twlatest
     - TOX_ENV=py33-twtrunk
+    - TOX_ENV=py34-tw160
+    - TOX_ENV=py34-tw163
+    - TOX_ENV=py34-twlatest
     - TOX_ENV=py34-twtrunk
+    - TOX_ENV=py35-tw160
+    - TOX_ENV=py35-tw163
+    - TOX_ENV=py35-twlatest
     - TOX_ENV=py35-twtrunk
+    - TOX_ENV=pypy-tw140
+    - TOX_ENV=pypy-tw150
+    - TOX_ENV=pypy-tw155
+    - TOX_ENV=pypy-tw160
+    - TOX_ENV=pypy-tw163
+    - TOX_ENV=pypy-twlatest
     - TOX_ENV=pypy-twtrunk
     - TOX_ENV=pyflakes
     - TOX_ENV=manifest

--- a/tests/mongod.py
+++ b/tests/mongod.py
@@ -66,6 +66,7 @@ class Mongod(object):
                 b"--dbpath", self.__datadir,
                 b"--noprealloc", b"--nojournal",
                 b"--smallfiles", b"--nssize", b"1",
+                b"--oplogSize", b"1",
                 b"--nohttpinterface",
         ]
         if self.auth: args.append(b"--auth")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -273,9 +273,9 @@ class TestMongoDBCR(unittest.TestCase):
         yield mongod_noauth.start()
 
         try:
-            conn = connection.MongoConnection(mongo_host, mongo_port)
-
             try:
+                conn = connection.MongoConnection(mongo_host, mongo_port)
+
                 ismaster = yield conn.admin.command("ismaster")
                 if ismaster["maxWireVersion"] < 3:
                     raise unittest.SkipTest("This test is only for MongoDB 3.0")
@@ -286,8 +286,10 @@ class TestMongoDBCR(unittest.TestCase):
                                                            upsert=True)
             finally:
                 yield conn.disconnect()
-        finally:
-            yield mongod_noauth.stop()
+                yield mongod_noauth.stop()
+        except unittest.SkipTest:
+            shutil.rmtree(self.dbpath)
+            raise
 
         self.mongod = Mongod(port=mongo_port, auth=True, dbpath=self.dbpath)
         yield self.mongod.start()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    {py26,py27,pypy}-{twlatest,twtrunk,tw154,tw153,tw150,tw140},{py33,py34,py35}-{twtrunk},
+    {py27,pypy}-{tw155,tw150,tw140},
+    {py27,py33,py34,py35,pypy}-{tw160,tw163,twtrunk,twlatest},
     pyflakes, manifest
 
 
@@ -13,8 +14,9 @@ deps =
     pycrypto
     twlatest: Twisted
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
-    tw154: Twisted==15.4
-    tw153: Twisted==15.3
+    tw163: Twisted==16.3.0
+    tw160: Twisted==16.0.0
+    tw155: Twisted==15.5
     tw150: Twisted==15.0
     tw140: Twisted==14.0
 setenv =

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division
 import io
 import struct
-import bson
 import collections
 from bson import BSON, ObjectId
 from bson.code import Code


### PR DESCRIPTION
Small tests improvements:
• `test_replicaset.py` was using 3 GB of temporary disk space (1GB oplog per 3 `mongod` instances)
• `test_auth.py` might leak directories in `/tmp` when ran against MongoDB v3
• Not testing with py26
• Test all supported configurations: py27 + Twisted ≥14, py3x + Twisted ≥16, pypy + Twisted ≥14

But the number of test configurations doubled, which will make Travis tests to run longer