### PR TITLE
Pinging server(s) and drop connections if server is gone

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -20,6 +20,9 @@ API Changes
 ^^^^^^^^^^^
 
 - ``Database.command()`` now takes ``codec_options`` argument.
+- ``watchdog_interval`` and ``watchdog_timeout`` arguments of ``ConnectionPool`` renamed
+  to ``ping_interval`` and ``ping_timeout`` correspondingly along with internal change of
+  connection aliveness checking mechanism.
 
 Bugfixes
 ^^^^^^^^

--- a/tests/test_cancel.py
+++ b/tests/test_cancel.py
@@ -68,7 +68,7 @@ class TestCancelParts(unittest.TestCase):
     @defer.inlineCallbacks
     def test_connection_notifyReady(self):
         uri = parse_uri("mongodb://localhost:27017/")
-        conn = _Connection(None, uri, 0, 10, 10, 10, 10)
+        conn = _Connection(None, uri, 0, 10, 10)
         d1 = conn.notifyReady()
         d2 = conn.notifyReady()
         d1.cancel()

--- a/tests/test_replicaset.py
+++ b/tests/test_replicaset.py
@@ -279,8 +279,7 @@ class TestReplicaSet(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_StaleConnection(self):
-        conn = MongoConnection("localhost", self.ports[0],
-                               watchdog_interval=10, watchdog_timeout=5)
+        conn = MongoConnection("localhost", self.ports[0], ping_interval = 5, ping_timeout = 5)
         try:
             yield conn.db.coll.count()
             self.__mongod[0].kill(signal.SIGSTOP)

--- a/tests/test_replicaset.py
+++ b/tests/test_replicaset.py
@@ -282,6 +282,9 @@ class TestReplicaSet(unittest.TestCase):
         conn = MongoConnection("localhost", self.ports[0], ping_interval = 5, ping_timeout = 5)
         try:
             yield conn.db.coll.count()
+            # check that 5s pingers won't break connection if it is healthy
+            yield self.__sleep(6)
+            yield conn.db.coll.count()
             self.__mongod[0].kill(signal.SIGSTOP)
             yield self.__sleep(0.2)
             while True:


### PR DESCRIPTION
*This PR is not for merging now, but mostly for discussion of the issue and the ways of solution*

Checking regularly that server nodes that we are connected to are alive and dropping connections if they are not.

This is one of possible approaches to solve the issue: if the network link is disappears between us and MongoDB server, how can we deal with it?

Currently TxMongo regularly sends `ismaster` command to all connections in the pool and drops connection if no answer received within a timeout. But this has a downside: if connection is waiting for a very long-running query, it won't receive `ismaster` response and will be dropped by this watchdog procedure.

What do you think about suggested technique? Does it cover all the scenarios? Can the code be simplified?