### PR TITLE
Multi-key sort specs and hints fixed

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -13,6 +13,11 @@ Features
 - ``codec_options`` properties for ``ConnectionPool``, ``Database`` and ``Collection``.
   ``Collection.with_options(codec_options=CodecOptions(document_class=...))`` is now preferred
   over ``Collection.find(..., as_class=...)``.
+  
+Bugfixes
+^^^^^^^^
+
+- Fixed bug in `find()` that can cause undefined ordering of the results when sorting on multiple fields is requested.
 
 Release 16.1.0 (2016-06-15)
 ---------------------------

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -272,7 +272,7 @@ class Collection(object):
 
             for k, v in c_filter.items():
                 if isinstance(v, (list, tuple)):
-                    spec['$' + k] = dict(v)
+                    spec['$' + k] = SON(v)
                 else:
                     spec['$' + k] = v
 


### PR DESCRIPTION
TxMongo has the serious bug: if sorting specification or hint contains several fields, it gets transformed to a `dict` before issuing the query, so the real fields order in BSON is undefined and so ordering is undefined too.

This patch fixes it by using `SON` instead of `dict`. Unfortunately, I can't imagine how to make an unintrusive test case for this except making `Collection.__apply_find_filter` non-private and test by calling it.