### PR TITLE
GridFS index fixed. codec_options argument for Database.command.

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -16,6 +16,16 @@ Features
   as it may create *very* variable conditions in terms of loading and timing. An additional index is		
   also added to facilitate bi-directional movement between versions. Additional Unit test for GFS also added.
 
+API Changes
+^^^^^^^^^^^
+
+- ``Database.command()`` now takes ``codec_options`` argument.
+
+Bugfixes
+^^^^^^^^
+
+- ``GridFS.get_last_version()`` was creating redundant index
+
 Release 16.2.0 (2016-10-02)
 ---------------------------
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -20,7 +20,7 @@ import time
 from io import BytesIO as StringIO
 
 import os
-from bson import objectid, timestamp
+from bson import objectid, timestamp, SON
 from pymongo.write_concern import WriteConcern
 import txmongo
 from txmongo import database, collection, filter as qf
@@ -389,5 +389,13 @@ class TestGridFsObjects(unittest.TestCase):
         self.assertNotEqual(gfs.indexes_created(), gfs.indexes_created())
 
         yield gfs.indexes_created()
+
+        indexes = yield db.fs.files.index_information()
+        self.assertTrue(any(key["key"] == SON([("filename", 1), ("uploadDate", 1)])
+                            for key in indexes.values()))
+
+        indexes = yield db.fs.chunks.index_information()
+        self.assertTrue(any(key["key"] == SON([("files_id", 1), ("n", 1)])
+                            for key in indexes.values()))
 
         yield conn.disconnect()

--- a/txmongo/_gridfs/__init__.py
+++ b/txmongo/_gridfs/__init__.py
@@ -61,7 +61,7 @@ class GridFS(object):
         self.__chunks = self.__collection.chunks
         self.__indexes_created_defer = defer.DeferredList([
             self.__files.create_index(
-                filter.sort(ASCENDING("filesname") + ASCENDING("uploadDate"))),
+                filter.sort(ASCENDING("filename") + ASCENDING("uploadDate"))),
             self.__chunks.create_index(
                 filter.sort(ASCENDING("files_id") + ASCENDING("n")), unique=True)
         ])
@@ -194,8 +194,6 @@ class GridFS(object):
 
         .. versionadded:: 1.6
         """
-        self.__files.ensure_index(filter.sort(ASCENDING("filename") + DESCENDING("uploadDate")))
-
         def ok(doc):
             if doc is None:
                 raise NoFile("TxMongo: no file in gridfs with filename {0}".format(repr(filename)))

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 from bson.son import SON
+from bson.codec_options import DEFAULT_CODEC_OPTIONS
 from pymongo.helpers import _check_command_response
 from twisted.python.compat import unicode
 from txmongo.collection import Collection
@@ -52,7 +53,8 @@ class Database(object):
         return self.__codec_options or self.__factory.codec_options
 
     @timeout
-    def command(self, command, value=1, check=True, allowable_errors=None, **kwargs):
+    def command(self, command, value=1, check=True, allowable_errors=None,
+                codec_options=DEFAULT_CODEC_OPTIONS, **kwargs):
         if isinstance(command, (bytes, unicode)):
             command = SON([(command, value)])
         options = kwargs.copy()
@@ -66,7 +68,7 @@ class Database(object):
 
             return response
 
-        ns = self["$cmd"]
+        ns = self["$cmd"].with_options(codec_options=codec_options)
         return ns.find_one(command, **kwargs).addCallback(on_ok)
 
 


### PR DESCRIPTION
It is funny and sad at the same time, but GridFS were creating index with a typo in field name and nobody noticed that :)

Also, `ensure_index` removed from `get_last_version` because ASC+ASC index, created in `__init__` is sufficient.

For the means of testing indexes creation, I've added `codec_options` argument to `Database.command()`. It can be used to make `command()` to return response as `SON` instead of plain `dict`.