### PR TITLE
ConnectionPool.drop_database

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -15,6 +15,7 @@ Features
   is the omission of searching by random (unindexed) meta-data which should be considered a bad idea		
   as it may create *very* variable conditions in terms of loading and timing. An additional index is		
   also added to facilitate bi-directional movement between versions. Additional Unit test for GFS also added.
+- New ``ConnectionPool.drop_database()`` method for easy and convenient destruction of all your precious data.
 
 API Changes
 ^^^^^^^^^^^

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -34,6 +34,7 @@ class TestMongoConnection(unittest.TestCase):
 
     @defer.inlineCallbacks
     def tearDown(self):
+        yield self.named_conn.drop_database("db")
         yield self.named_conn.disconnect()
         yield self.unnamed_conn.disconnect()
 
@@ -75,3 +76,38 @@ class TestMongoConnection(unittest.TestCase):
             d_insert = self.named_conn.db.coll.find_one(
                 {'x': 42}, deadline=time()+2)
             yield self.assertFailure(d_insert, TimeExceeded)
+
+
+class TestDropDatabase(unittest.TestCase):
+
+    @defer.inlineCallbacks
+    def setUp(self):
+        self.conn = connection.ConnectionPool()
+        self.db = self.conn.db
+        self.coll = self.db.coll
+        yield self.coll.insert({'x': 42})
+        yield self.assert_coll_count(1)
+
+    @defer.inlineCallbacks
+    def tearDown(self):
+        yield self.conn.drop_database(self.db)
+        yield self.conn.disconnect()
+
+    @defer.inlineCallbacks
+    def assert_coll_count(self, n):
+        self.assertEqual((yield self.coll.count()), n)
+
+    @defer.inlineCallbacks
+    def test_by_name(self):
+        yield self.conn.drop_database("db")
+        yield self.assert_coll_count(0)
+
+    def test_invalid_args(self):
+        self.assertRaises(TypeError, self.conn.drop_database, 42)
+        self.assertRaises(TypeError, self.conn.drop_database, self.conn)
+        self.assertRaises(TypeError, self.conn.drop_database, self.coll)
+
+    @defer.inlineCallbacks
+    def test_by_object(self):
+        yield self.conn.drop_database(self.db)
+        yield self.assert_coll_count(0)

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -328,6 +328,17 @@ class ConnectionPool(object):
         else:
             return None
 
+    def drop_database(self, name_or_database):
+        if isinstance(name_or_database, (bytes, StringType)):
+            db = self[name_or_database]
+        elif isinstance(name_or_database, Database):
+            db = name_or_database
+        else:
+            raise TypeError("argument to drop_database() should be database name "
+                            "or database object")
+
+        return db.command("dropDatabase")
+
     def disconnect(self):
         for factory in self.__pool:
             factory.stopTrying()


### PR DESCRIPTION
API is following PyMongo's `MongoClient.drop_database()`