### PR TITLE
New signature for find() method and compatibility with old one

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -20,6 +20,20 @@ Features
 API Changes
 ^^^^^^^^^^^
 
+- ``find()``, ``find_one()``, ``find_with_cursor()``, ``count()`` and ``distinct()`` signatures
+  changed to more closely match PyMongo's counterparts. New signatures are:
+  
+  - ``find(filter=None, projection=None, skip=0, limit=0, sort=None, **kwargs)``
+  - ``find_with_cursor(filter=None, projection=None, skip=0, limit=0, sort=None, **kwargs)``
+  - ``find_one(filter=None, projection=None, **kwargs)``
+  - ``count(filter=None, **kwargs)``
+  - ``distinct(key, filter=None, **kwargs)``
+  
+  Old signatures are now deprecated and will be supported in this and one subsequent releases. 
+  After that only new signatures will be valid.
+- ``cursor`` argument to ``find()`` is deprecated. Please use ``find_with_cursor()`` directly
+  if you need to iterate over results by batches. ``cursor`` will be supported in this and
+  one subsequent releases.
 - ``Database.command()`` now takes ``codec_options`` argument.
 - ``watchdog_interval`` and ``watchdog_timeout`` arguments of ``ConnectionPool`` renamed
   to ``ping_interval`` and ``ping_timeout`` correspondingly along with internal change of

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -34,6 +34,9 @@ API Changes
 - ``cursor`` argument to ``find()`` is deprecated. Please use ``find_with_cursor()`` directly
   if you need to iterate over results by batches. ``cursor`` will be supported in this and
   one subsequent releases.
+- ``as_class`` argument to ``find()``, ``find_with_cursor()`` and ``find_one()`` is deprecated.
+  Please use ``collection.with_options(codec_options=CodecOptions(document_class=...)).find()`
+  instead. It is lengthty, but it is more generic and this is how you do it with current PyMongo.
 - ``Database.command()`` now takes ``codec_options`` argument.
 - ``watchdog_interval`` and ``watchdog_timeout`` arguments of ``ConnectionPool`` renamed
   to ``ping_interval`` and ``ping_timeout`` correspondingly along with internal change of

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -369,3 +369,71 @@ class TestCreateCollection(unittest.TestCase):
         else:
             self.fail()
     test_Fail.timeout = 10
+
+
+class TestFindSignatureCompat(unittest.TestCase):
+    def test_convert(self):
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}),
+            {"spec": {'x': 42}, "projection": None, "skip": 0, "limit": 0, "filter": None}
+        )
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}, unknown_arg=123),
+            {"spec": {'x': 42}, "projection": None, "skip": 0, "limit": 0, "filter": None,
+             "unknown_arg": 123}
+        )
+        self.assertEqual(
+            Collection._find_args_compat(spec={'x': 42}),
+            {"spec": {'x': 42}, "projection": None, "skip": 0, "limit": 0, "filter": None}
+        )
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}, {'a': 1}),
+            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 0, "limit": 0, "filter": None}
+        )
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}, projection={'a': 1}),
+            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 0, "limit": 0, "filter": None}
+        )
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}, fields={'a': 1}),
+            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 0, "limit": 0, "filter": None,
+             "cursor": False}
+        )
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}, 5),
+            {"spec": {'x': 42}, "projection": None, "skip": 5, "limit": 0, "filter": None,
+             "cursor": False}
+        )
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}, {'a': 1}, 5),
+            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 0, "filter": None}
+        )
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}, {'a': 1}, 5, 6),
+            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6, "filter": None}
+        )
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}, 5, 6, {'a': 1}),
+            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6, "filter": None,
+             "cursor": False}
+        )
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}, {'a': 1}, 5, 6, qf.sort([('s', 1)])),
+            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
+             "filter": qf.sort([('s', 1)])}
+        )
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}, 5, 6, {'a': 1}, qf.sort([('s', 1)])),
+            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
+             "filter": qf.sort([('s', 1)]), "cursor": False}
+        )
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}, 5, 6, {'a': 1}, qf.sort([('s', 1)]), True),
+            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
+             "filter": qf.sort([('s', 1)]), "cursor": True}
+        )
+        self.assertEqual(
+            Collection._find_args_compat({'x': 42}, filter=qf.sort([('s', 1)]), limit=6, projection={'a': 1}, skip=5),
+            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
+             "filter": qf.sort([('s', 1)])}
+        )

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -374,66 +374,88 @@ class TestCreateCollection(unittest.TestCase):
 class TestFindSignatureCompat(unittest.TestCase):
     def test_convert(self):
         self.assertEqual(
+            Collection._find_args_compat(spec={'x': 42}),
+            {"filter": {'x': 42}, "projection": None, "skip": 0, "limit": 0, "sort": None,
+             "cursor": False}
+        )
+        self.assertEqual(
+            Collection._find_args_compat(filter={'x': 42}),
+            {"filter": {'x': 42}, "projection": None, "skip": 0, "limit": 0, "sort": None}
+        )
+        self.assertEqual(
+            Collection._find_args_compat(filter=qf.sort(qf.ASCENDING('x'))),
+            {"filter": None, "projection": None, "skip": 0, "limit": 0,
+             "sort": qf.sort(qf.ASCENDING('x')), "cursor": False}
+        )
+        self.assertEqual(
+            Collection._find_args_compat(sort=qf.sort(qf.ASCENDING('x'))),
+            {"filter": None, "projection": None, "skip": 0, "limit": 0,
+             "sort": qf.sort(qf.ASCENDING('x'))}
+        )
+        self.assertEqual(
             Collection._find_args_compat({'x': 42}),
-            {"spec": {'x': 42}, "projection": None, "skip": 0, "limit": 0, "filter": None}
+            {"filter": {'x': 42}, "projection": None, "skip": 0, "limit": 0, "sort": None}
         )
         self.assertEqual(
             Collection._find_args_compat({'x': 42}, unknown_arg=123),
-            {"spec": {'x': 42}, "projection": None, "skip": 0, "limit": 0, "filter": None,
+            {"filter": {'x': 42}, "projection": None, "skip": 0, "limit": 0, "sort": None,
              "unknown_arg": 123}
         )
         self.assertEqual(
-            Collection._find_args_compat(spec={'x': 42}),
-            {"spec": {'x': 42}, "projection": None, "skip": 0, "limit": 0, "filter": None}
-        )
-        self.assertEqual(
             Collection._find_args_compat({'x': 42}, {'a': 1}),
-            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 0, "limit": 0, "filter": None}
+            {"filter": {'x': 42}, "projection": {'a': 1}, "skip": 0, "limit": 0, "sort": None}
         )
         self.assertEqual(
             Collection._find_args_compat({'x': 42}, projection={'a': 1}),
-            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 0, "limit": 0, "filter": None}
+            {"filter": {'x': 42}, "projection": {'a': 1}, "skip": 0, "limit": 0, "sort": None}
         )
         self.assertEqual(
             Collection._find_args_compat({'x': 42}, fields={'a': 1}),
-            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 0, "limit": 0, "filter": None,
+            {"filter": {'x': 42}, "projection": {'a': 1}, "skip": 0, "limit": 0, "sort": None,
              "cursor": False}
         )
         self.assertEqual(
             Collection._find_args_compat({'x': 42}, 5),
-            {"spec": {'x': 42}, "projection": None, "skip": 5, "limit": 0, "filter": None,
+            {"filter": {'x': 42}, "projection": None, "skip": 5, "limit": 0, "sort": None,
              "cursor": False}
         )
         self.assertEqual(
             Collection._find_args_compat({'x': 42}, {'a': 1}, 5),
-            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 0, "filter": None}
+            {"filter": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 0, "sort": None}
         )
         self.assertEqual(
             Collection._find_args_compat({'x': 42}, {'a': 1}, 5, 6),
-            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6, "filter": None}
+            {"filter": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6, "sort": None}
         )
         self.assertEqual(
             Collection._find_args_compat({'x': 42}, 5, 6, {'a': 1}),
-            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6, "filter": None,
+            {"filter": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6, "sort": None,
              "cursor": False}
         )
         self.assertEqual(
             Collection._find_args_compat({'x': 42}, {'a': 1}, 5, 6, qf.sort([('s', 1)])),
-            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
-             "filter": qf.sort([('s', 1)])}
+            {"filter": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
+             "sort": qf.sort([('s', 1)])}
         )
         self.assertEqual(
             Collection._find_args_compat({'x': 42}, 5, 6, {'a': 1}, qf.sort([('s', 1)])),
-            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
-             "filter": qf.sort([('s', 1)]), "cursor": False}
+            {"filter": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
+             "sort": qf.sort([('s', 1)]), "cursor": False}
         )
         self.assertEqual(
             Collection._find_args_compat({'x': 42}, 5, 6, {'a': 1}, qf.sort([('s', 1)]), True),
-            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
-             "filter": qf.sort([('s', 1)]), "cursor": True}
+            {"filter": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
+             "sort": qf.sort([('s', 1)]), "cursor": True}
         )
         self.assertEqual(
-            Collection._find_args_compat({'x': 42}, filter=qf.sort([('s', 1)]), limit=6, projection={'a': 1}, skip=5),
-            {"spec": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
-             "filter": qf.sort([('s', 1)])}
+            Collection._find_args_compat(spec={'x': 42}, filter=qf.sort([('s', 1)]), limit=6,
+                                         fields={'a': 1}, skip=5),
+            {"filter": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
+             "sort": qf.sort([('s', 1)]), "cursor": False}
+        )
+        self.assertEqual(
+            Collection._find_args_compat(filter={'x': 42}, sort=qf.sort([('s', 1)]), limit=6,
+                                         projection={'a': 1}, skip=5),
+            {"filter": {'x': 42}, "projection": {'a': 1}, "skip": 5, "limit": 6,
+             "sort": qf.sort([('s', 1)])}
         )

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1038,3 +1038,24 @@ class TestCount(SingleCollectionTest):
         self.assertEqual((yield self.coll.count({'x': {"$gt": 15}})), 2)
 
         self.assertEqual((yield self.db.non_existing.count()), 0)
+
+    @defer.inlineCallbacks
+    def test_hint(self):
+        yield self.coll.create_index(qf.sort(qf.ASCENDING('x')))
+
+        cnt = yield self.coll.count(hint=qf.hint(qf.ASCENDING('x')))
+        self.assertEqual(cnt, 3)
+
+        yield self.assertFailure(self.coll.count(hint=qf.hint(qf.ASCENDING('y'))),
+                                 OperationFailure)
+
+        self.assertRaises(TypeError, self.coll.count, hint={'x': 1})
+        self.assertRaises(TypeError, self.coll.count, hint=[('x', 1)])
+
+    @defer.inlineCallbacks
+    def test_skip_limit(self):
+        cnt = yield self.coll.count(limit = 2)
+        self.assertEqual(cnt, 2)
+
+        cnt = yield self.coll.count(skip = 1)
+        self.assertEqual(cnt, 2)

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -1045,10 +1045,11 @@ class Collection(object):
         return self._database("admin").command("renameCollection", str(self), to=to, **kwargs)
 
     @timeout
-    def distinct(self, key, spec=None, **kwargs):
+    def distinct(self, key, filter=None, **kwargs):
         params = {"key": key}
-        if spec:
-            params["query"] = spec
+        filter = kwargs.pop("spec", filter)
+        if filter:
+            params["query"] = filter
         params.update(kwargs)
 
         return self._database.command("distinct", self._collection_name, **params)\

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -454,10 +454,10 @@ class Collection(object):
             .addCallback(lambda result: result[0] if result else None)
 
     @timeout
-    def count(self, spec=None, **kwargs):
+    def count(self, filter=None, **kwargs):
         """Get the number of documents in this collection.
 
-        :param spec:
+        :param filter:
             argument is a query document that selects which documents to
             count in the collection.
 
@@ -467,8 +467,11 @@ class Collection(object):
         :returns: a :class:`Deferred` that called back with a number of
                   documents matching the criteria.
         """
+        if "spec" in kwargs:
+            filter = kwargs["spec"]
+
         return self._database.command("count", self._collection_name,
-                                      query=spec or SON(), **kwargs)\
+                                      query=filter or SON(), **kwargs)\
                    .addCallback(lambda result: int(result['n']))
 
     @timeout

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -464,11 +464,23 @@ class Collection(object):
         :param hint: *(keyword only)*
             :class:`~txmongo.filter.hint` instance specifying index to use.
 
+        :param int limit: *(keyword only)*
+            The maximum number of documents to count.
+
+        :param int skip: *(keyword only)*
+            The number of matching documents to skip before returning results.
+
         :returns: a :class:`Deferred` that called back with a number of
                   documents matching the criteria.
         """
         if "spec" in kwargs:
             filter = kwargs["spec"]
+
+        if "hint" in kwargs:
+            hint = kwargs["hint"]
+            if not isinstance(hint, qf.hint):
+                raise TypeError("hint must be an instance of txmongo.filter.hint")
+            kwargs["hint"] = SON(kwargs["hint"]["hint"])
 
         return self._database.command("count", self._collection_name,
                                       query=filter or SON(), **kwargs)\


### PR DESCRIPTION
Continuing #55

I suggest to change signature of `find()`, `find_with_cursor()` and `find_one()` to more closely match PyMongo's counterparts.

Now it is `(spec=None, skip=0, limit=0, fields=None, filter=None, cursor=False, **kwargs)`
I'm proposing to change it to `(spec=None, projection=None, skip=0, limit=0, filter=None, **kwargs)`

It can be breaking if done immediately, but we can do it with deprecation interval. This PR makes `find*()` to accept both old and new signatures with issuing DeprecationWarning for the old one.

* Short form `find({'x': 1}, {'_id': 0})` becames compatible with PyMongo
* Keyworded form `find({'x': 1}, projection={'_id': 0})` too
* I suggest to deprecate `cursor` argument to `find()` in favor of `find_with_cursor()`. `cursor=True` changes behavior and semantics of `find()` completely, so it is better looking to have distinct method for this.

Further thoughts:
May be it worth to also rename `spec` and `filter` to `filter` and `sort` correspondingly?
Pros:
* `filter` becames compatible with PyMongo
* `sort` becames more like in `find_one_for_update`

Cons:
* `sort` is not technically correct term because it may be used also for hints, comments, etc.
* `find(filter={'x': 1})` will not be 100%-distinguishable between old and new variants.