### PR TITLE
gc optimization in Collection.bulk_write

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Release 17.1.0 (UNRELEASED)
+---------------------------
+
+Bugfixes
+^^^^^^^^
+
+- Memory leak fixed in `Collection.bulk_write()`
+
 Release 16.3.0 (2016-11-25)
 ---------------------------
 


### PR DESCRIPTION
When implementing `bulk_write` I did the same mistake that was once fixed in #140 for `find_with_cursor`. 

In CPython, inner function referencing itself creates circular reference between function object and its closure. Quick proof:
```python
def f():
    def g():
        g()

print(gc.get_count()[0])
for _ in range(100000): f()
print(gc.get_count()[0])
```
It outputs something like `428` and `300395`, which means that each call to `f()` leaves 3 non-collected objects for GC. Note that `g()` is not even called.

This patch removes such circular-references in `Collection._execute_bulk` and `Collection._execute_batch_command` in a ugly but working way: by passing function references as arguments into the functions themselves.

```python
before = gc.get_count()[0]
for i in range(10000):
    coll.bulk_write([InsertOne({'x': 42})])
yield coll.count()
after = gc.get_count()[0]
print(after - before)
```
Before: 410001
After: 1

This should significantly affect the number of GC triggerings at write-intensive use cases.