### PR TITLE
Auth using authsource db

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -8,6 +8,7 @@ Bugfixes
 ^^^^^^^^
 
 - Memory leak fixed in `Collection.bulk_write()`
+- Use authSource as auth database if specify in connect uri
 
 Release 16.3.0 (2016-11-25)
 ---------------------------

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -272,7 +272,8 @@ class ConnectionPool(object):
         ]
 
         if self.__uri['database'] and self.__uri['username'] and self.__uri['password']:
-            self.authenticate(self.__uri['database'], self.__uri['username'],
+            auth_db = self.__uri['options'].get('authsource') or self.__uri['database']
+            self.authenticate(auth_db, self.__uri['username'],
                               self.__uri['password'],
                               self.__uri['options'].get('authmechanism', 'DEFAULT'))
 


### PR DESCRIPTION
Use 'authsource' as auth database, if specify in uri, and orig database if not.

https://docs.mongodb.com/manual/reference/connection-string/#urioption.authSource