### PR TITLE
Tests fixed for MongoDB 3.4

### DIFF
--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -298,12 +298,6 @@ class TestLimit(SingleCollectionTest):
         res = yield self.coll.find(limit=-150)
         self.assertEqual(len(res), 150)
 
-    @defer.inlineCallbacks
-    def test_HardLimitAboveMessageSizeThreshold(self):
-        yield self.coll.insert([{'v': ' '*(2**20)} for _ in range(8)], safe=True)
-        res = yield self.coll.find(limit=-6)
-        self.assertEqual(len(res), 4)
-
 
 class TestSkip(SingleCollectionTest):
 
@@ -381,8 +375,13 @@ class TestCommand(SingleCollectionTest):
         result = yield self.db.command("delete", "mycol", check=False)
         self.assertFalse(result["ok"])
 
-        result = yield self.db.command("delete", "mycol", check=True,
-                                       allowable_errors=["missing deletes field"])
+        result = yield self.db.command(
+            "delete", "mycol", check=True,
+            allowable_errors=[
+                "missing deletes field",
+                "The deletes option is required to the delete command."
+            ]
+        )
         self.assertFalse(result["ok"])
 
 

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -1021,7 +1021,7 @@ class Collection(object):
                 .addCallback(lambda _: name)
 
     @timeout
-    def ensure_index(self, sort_fields, **kwargs):
+    def ensure_index(self, sort_fields, _deadline=None, **kwargs):
         # ensure_index is an alias of create_index since we are not
         # keeping an index cache same way pymongo does
         return self.create_index(sort_fields, **kwargs)


### PR DESCRIPTION
I've noticed that several tests were failing against modern MongoDB 3.4

1. https://github.com/twisted/txmongo/compare/master...IlyaSkriblovsky:mongodb-3.4-tests-fixed?expand=1#diff-cecc483f704c4be15eaed66c3bb3678bL302
MongoDB 3.4 [changed behavior of the first batch of `find()` command](https://docs.mongodb.com/v3.4/tutorial/iterate-a-cursor/#cursor-batches). Before it was returning maximum of 1mb in the first batch, now this restriction is loosened, so this test fails. Actually I think this test is redundant, it was checking that negative limit forces only the single batch in result. It is not our concern anyways.

2. https://github.com/twisted/txmongo/compare/master...IlyaSkriblovsky:mongodb-3.4-tests-fixed?expand=1#diff-cecc483f704c4be15eaed66c3bb3678bL384
MongoDB 3.4 changed error message in that case

3. https://github.com/twisted/txmongo/compare/master...IlyaSkriblovsky:mongodb-3.4-tests-fixed?expand=1#diff-1f3700c74d32647bfd888de73a25b21dL1025
This one is actually a bug. Ghost `_deadline` kwarg were added in index specification by `create_index`. MongoDB ≤3.2 just ignores it, so it wasn't noticed. 3.4 throws an error here.