### PR TITLE
17.1.0

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,14 +1,15 @@
 Changelog
 =========
 
-Release 17.1.0 (UNRELEASED)
+Release 17.1.0 (2017-08-11)
 ---------------------------
 
 Bugfixes
 ^^^^^^^^
 
 - Memory leak fixed in `Collection.bulk_write()`
-- Use authSource as auth database if specify in connect uri
+- Use `authSource` as auth database if specified in connect uri
+- Compatibility with PyMongo 3.5.0+
 
 Release 16.3.0 (2016-11-25)
 ---------------------------


### PR DESCRIPTION
I believe that quick fix from #211 deserves a release because simple `pip install txmongo` results in broken installation right now (since it installs txmongo 16.3.0 and pymongo 3.5.0 which are not compatible).

Should we name the new release 17.1.0? Or may be 16.3.1 because it consists only of bugfixes?