### PR TITLE
Fixing compatibility with pymongo 3.6

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Release 17.2.0 (UNRELEASED)
+---------------------------
+
+Bugfixes
+^^^^^^^^
+
+- Fixed compatibility with PyMongo 3.6
+
 Release 17.1.0 (2017-08-11)
 ---------------------------
 


### PR DESCRIPTION
PyMongo 3.6 changed behavior of private `pymongo.helpers._check_write_command_response()` function. I've copied it into `txmongo.collection` to avoid future compatibility issues.

See #218 