### PR TITLE
Fix aggregate with Mongo 3.6

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Release 18.1.0 (UNRELEASED)
+---------------------------
+
+Bugfixes
+^^^^^^^^
+
+- Fixed compatibility of `Collection.aggregate()` with PyMongo 3.6
+
+
 Release 18.0.0 (2018-01-02)
 ---------------------------
 
@@ -30,8 +39,8 @@ Features
 - Client authentication by X509 certificates. Use your client certificate when connecting
   to MongoDB and then call ``Database.authenticate`` with certificate subject as username,
   empty password and ``mechanism="MONGODB-X509"``.
-- ``get_version()`` to approximate the behaviour of get_version in PyMongo. One noteable exception		
-  is the omission of searching by random (unindexed) meta-data which should be considered a bad idea		
+- ``get_version()`` to approximate the behaviour of get_version in PyMongo. One noteable exception
+  is the omission of searching by random (unindexed) meta-data which should be considered a bad idea
   as it may create *very* variable conditions in terms of loading and timing.
 - New ``ConnectionPool.drop_database()`` method for easy and convenient destruction of all your precious data.
 - ``count()`` to return the number of versions of any given file in GridFS.
@@ -41,14 +50,14 @@ API Changes
 
 - ``find()``, ``find_one()``, ``find_with_cursor()``, ``count()`` and ``distinct()`` signatures
   changed to more closely match PyMongo's counterparts. New signatures are:
-  
+
   - ``find(filter=None, projection=None, skip=0, limit=0, sort=None, **kwargs)``
   - ``find_with_cursor(filter=None, projection=None, skip=0, limit=0, sort=None, **kwargs)``
   - ``find_one(filter=None, projection=None, **kwargs)``
   - ``count(filter=None, **kwargs)``
   - ``distinct(key, filter=None, **kwargs)``
-  
-  Old signatures are now deprecated and will be supported in this and one subsequent releases. 
+
+  Old signatures are now deprecated and will be supported in this and one subsequent releases.
   After that only new signatures will be valid.
 - ``cursor`` argument to ``find()`` is deprecated. Please use ``find_with_cursor()`` directly
   if you need to iterate over results by batches. ``cursor`` will be supported in this and
@@ -78,7 +87,7 @@ Features
 - ``codec_options`` properties for ``ConnectionPool``, ``Database`` and ``Collection``.
   ``Collection.with_options(codec_options=CodecOptions(document_class=...))`` is now preferred
   over ``Collection.find(..., as_class=...)``.
-  
+
 Bugfixes
 ^^^^^^^^
 

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -12,24 +12,18 @@ from bson.code import Code
 from bson.son import SON
 from bson.codec_options import CodecOptions
 from pymongo.bulk import _Bulk, _COMMANDS, _merge_command
-from pymongo.errors import (
-    InvalidName, BulkWriteError, InvalidOperation, OperationFailure, DuplicateKeyError,
+from pymongo.errors import InvalidName, BulkWriteError, InvalidOperation, OperationFailure, DuplicateKeyError, \
     WriteError, WTimeoutError, WriteConcernError
-)
 from pymongo.message import _OP_MAP, _INSERT
-from pymongo.results import (
-    InsertOneResult, InsertManyResult, UpdateResult, DeleteResult, BulkWriteResult
-)
-from pymongo.common import (
-    validate_ok_for_update, validate_ok_for_replace, validate_is_mapping, validate_boolean
-)
+from pymongo.results import InsertOneResult, InsertManyResult, UpdateResult, \
+    DeleteResult, BulkWriteResult
+from pymongo.common import validate_ok_for_update, validate_ok_for_replace, \
+    validate_is_mapping, validate_boolean
 from pymongo.collection import ReturnDocument
 from pymongo.write_concern import WriteConcern
 from txmongo.filter import _QueryFilter
-from txmongo.protocol import (
-    DELETE_SINGLE_REMOVE, UPDATE_UPSERT, UPDATE_MULTI, Query, Getmore, Insert, Update,
-    Delete, KillCursors
-)
+from txmongo.protocol import DELETE_SINGLE_REMOVE, UPDATE_UPSERT, UPDATE_MULTI, \
+    Query, Getmore, Insert, Update, Delete, KillCursors
 from txmongo.utils import check_deadline, timeout
 from txmongo import filter as qf
 from twisted.internet import defer
@@ -97,9 +91,7 @@ class Collection(object):
             msg = "TxMongo: collection names must not contain '$', '{0}'".format(repr(name))
             raise InvalidName(msg)
         if name[0] == "." or name[-1] == ".":
-            msg = "TxMongo: collection names must not start or end with '.', '{0}'".format(
-                repr(name)
-            )
+            msg = "TxMongo: collection names must not start or end with '.', '{0}'".format(repr(name))
             raise InvalidName(msg)
         if "\x00" in name:
             raise InvalidName("TxMongo: collection names must not contain the null character.")
@@ -234,8 +226,8 @@ class Collection(object):
                 return None
 
         return self._database.command(
-            SON([("listCollections", 1),
-                ("filter", {"name": self.name})])).addCallback(on_ok)
+                SON([("listCollections", 1),
+                     ("filter", {"name": self.name})])).addCallback(on_ok)
 
     @timeout
     def options(self, _deadline=None):
@@ -249,9 +241,7 @@ class Collection(object):
         """
         def on_3_0_fail(failure):
             failure.trap(OperationFailure)
-            return self._database.system.namespaces.find_one(
-                {"name": str(self)}, _deadline=_deadline
-            )
+            return self._database.system.namespaces.find_one({"name": str(self)}, _deadline=_deadline)
 
         def on_ok(result):
             if not result:
@@ -635,8 +625,8 @@ class Collection(object):
 
             write_concern = self._get_write_concern(safe, **kwargs)
             if write_concern.acknowledged:
-                return proto.get_last_error(
-                    str(self._database), **write_concern.document).addCallback(lambda _: ids)
+                return proto.get_last_error(str(self._database), **write_concern.document)\
+                        .addCallback(lambda _: ids)
 
             return ids
 
@@ -718,7 +708,7 @@ class Collection(object):
             key = str(idx).encode('ascii')
             value = BSON.encode(doc)
 
-            enough_size = buf.tell() + len(key) + 2 + len(value) - docs_start > max_bson
+            enough_size = buf.tell() + len(key)+2 + len(value) - docs_start > max_bson
             enough_count = idx >= max_count
             if enough_size or enough_count:
                 yield idx_offset, prepare_command()
@@ -1058,8 +1048,8 @@ class Collection(object):
             kwargs["bucketSize"] = kwargs.pop("bucket_size")
 
         index.update(kwargs)
-        return self._database.system.indexes.insert(
-            index, safe=True).addCallback(lambda _: name)
+        return self._database.system.indexes.insert(index, safe=True)\
+                .addCallback(lambda _: name)
 
     @timeout
     def ensure_index(self, sort_fields, _deadline=None, **kwargs):
@@ -1091,8 +1081,8 @@ class Collection(object):
             assert indexes_info["cursor"]["id"] == 0
             return indexes_info["cursor"]["firstBatch"]
         codec = CodecOptions(document_class=SON)
-        return self._database.command(
-            "listIndexes", self.name, codec_options=codec).addCallback(on_ok)
+        return self._database.command("listIndexes", self.name, codec_options=codec)\
+                .addCallback(on_ok)
 
     @timeout
     def index_information(self, _deadline=None):
@@ -1109,6 +1099,7 @@ class Collection(object):
             return info
 
         return self.__index_information_3_0().addErrback(on_3_0_fail).addCallback(on_ok)
+
 
     @timeout
     def rename(self, new_name, _deadline=None):
@@ -1160,13 +1151,12 @@ class Collection(object):
     def map_reduce(self, map, reduce, full_response=False, **kwargs):
         params = {"map": map, "reduce": reduce}
         params.update(**kwargs)
-
         def on_ok(raw):
             if full_response:
                 return raw
             return raw.get("results")
-        return self._database.command(
-            "mapreduce", self._collection_name, **params).addCallback(on_ok)
+        return self._database.command("mapreduce", self._collection_name, **params)\
+                .addCallback(on_ok)
 
     @timeout
     def find_and_modify(self, query=None, update=None, upsert=False, **kwargs):
@@ -1228,9 +1218,8 @@ class Collection(object):
 
         no_obj_error = "No matching object found"
 
-        return self._database.command(
-            cmd, allowable_errors=[no_obj_error], _deadline=_deadline
-        ).addCallback(lambda result: result.get("value"))
+        return self._database.command(cmd, allowable_errors=[no_obj_error], _deadline=_deadline)\
+                .addCallback(lambda result: result.get("value"))
 
     @timeout
     def find_one_and_delete(self, filter, projection=None, sort=None, _deadline=None):
@@ -1326,6 +1315,7 @@ class Collection(object):
 
         return iterate(iterate, on_cmd_result).addCallback(on_all_done)
 
+
     def _execute_batch_command(self, command_type, documents, ordered):
         assert command_type in _OP_MAP
 
@@ -1353,7 +1343,7 @@ class Collection(object):
 
             actual_write_concern = self.write_concern
             if ordered and self.write_concern.acknowledged is False:
-                actual_write_concern = WriteConcern(w=1)
+                actual_write_concern = WriteConcern(w = 1)
 
             batches = self._generate_batch_commands(self._collection_name, _COMMANDS[command_type],
                                                     _OP_MAP[command_type], documents, ordered,

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -12,18 +12,24 @@ from bson.code import Code
 from bson.son import SON
 from bson.codec_options import CodecOptions
 from pymongo.bulk import _Bulk, _COMMANDS, _merge_command
-from pymongo.errors import InvalidName, BulkWriteError, InvalidOperation, OperationFailure, DuplicateKeyError, \
+from pymongo.errors import (
+    InvalidName, BulkWriteError, InvalidOperation, OperationFailure, DuplicateKeyError,
     WriteError, WTimeoutError, WriteConcernError
+)
 from pymongo.message import _OP_MAP, _INSERT
-from pymongo.results import InsertOneResult, InsertManyResult, UpdateResult, \
-    DeleteResult, BulkWriteResult
-from pymongo.common import validate_ok_for_update, validate_ok_for_replace, \
-    validate_is_mapping, validate_boolean
+from pymongo.results import (
+    InsertOneResult, InsertManyResult, UpdateResult, DeleteResult, BulkWriteResult
+)
+from pymongo.common import (
+    validate_ok_for_update, validate_ok_for_replace, validate_is_mapping, validate_boolean
+)
 from pymongo.collection import ReturnDocument
 from pymongo.write_concern import WriteConcern
 from txmongo.filter import _QueryFilter
-from txmongo.protocol import DELETE_SINGLE_REMOVE, UPDATE_UPSERT, UPDATE_MULTI, \
-    Query, Getmore, Insert, Update, Delete, KillCursors
+from txmongo.protocol import (
+    DELETE_SINGLE_REMOVE, UPDATE_UPSERT, UPDATE_MULTI, Query, Getmore, Insert, Update,
+    Delete, KillCursors
+)
 from txmongo.utils import check_deadline, timeout
 from txmongo import filter as qf
 from twisted.internet import defer
@@ -91,7 +97,9 @@ class Collection(object):
             msg = "TxMongo: collection names must not contain '$', '{0}'".format(repr(name))
             raise InvalidName(msg)
         if name[0] == "." or name[-1] == ".":
-            msg = "TxMongo: collection names must not start or end with '.', '{0}'".format(repr(name))
+            msg = "TxMongo: collection names must not start or end with '.', '{0}'".format(
+                repr(name)
+            )
             raise InvalidName(msg)
         if "\x00" in name:
             raise InvalidName("TxMongo: collection names must not contain the null character.")
@@ -226,8 +234,8 @@ class Collection(object):
                 return None
 
         return self._database.command(
-                SON([("listCollections", 1),
-                     ("filter", {"name": self.name})])).addCallback(on_ok)
+            SON([("listCollections", 1),
+                ("filter", {"name": self.name})])).addCallback(on_ok)
 
     @timeout
     def options(self, _deadline=None):
@@ -241,7 +249,9 @@ class Collection(object):
         """
         def on_3_0_fail(failure):
             failure.trap(OperationFailure)
-            return self._database.system.namespaces.find_one({"name": str(self)}, _deadline=_deadline)
+            return self._database.system.namespaces.find_one(
+                {"name": str(self)}, _deadline=_deadline
+            )
 
         def on_ok(result):
             if not result:
@@ -625,8 +635,8 @@ class Collection(object):
 
             write_concern = self._get_write_concern(safe, **kwargs)
             if write_concern.acknowledged:
-                return proto.get_last_error(str(self._database), **write_concern.document)\
-                        .addCallback(lambda _: ids)
+                return proto.get_last_error(
+                    str(self._database), **write_concern.document).addCallback(lambda _: ids)
 
             return ids
 
@@ -708,7 +718,7 @@ class Collection(object):
             key = str(idx).encode('ascii')
             value = BSON.encode(doc)
 
-            enough_size = buf.tell() + len(key)+2 + len(value) - docs_start > max_bson
+            enough_size = buf.tell() + len(key) + 2 + len(value) - docs_start > max_bson
             enough_count = idx >= max_count
             if enough_size or enough_count:
                 yield idx_offset, prepare_command()
@@ -1048,8 +1058,8 @@ class Collection(object):
             kwargs["bucketSize"] = kwargs.pop("bucket_size")
 
         index.update(kwargs)
-        return self._database.system.indexes.insert(index, safe=True)\
-                .addCallback(lambda _: name)
+        return self._database.system.indexes.insert(
+            index, safe=True).addCallback(lambda _: name)
 
     @timeout
     def ensure_index(self, sort_fields, _deadline=None, **kwargs):
@@ -1081,8 +1091,8 @@ class Collection(object):
             assert indexes_info["cursor"]["id"] == 0
             return indexes_info["cursor"]["firstBatch"]
         codec = CodecOptions(document_class=SON)
-        return self._database.command("listIndexes", self.name, codec_options=codec)\
-                .addCallback(on_ok)
+        return self._database.command(
+            "listIndexes", self.name, codec_options=codec).addCallback(on_ok)
 
     @timeout
     def index_information(self, _deadline=None):
@@ -1099,7 +1109,6 @@ class Collection(object):
             return info
 
         return self.__index_information_3_0().addErrback(on_3_0_fail).addCallback(on_ok)
-
 
     @timeout
     def rename(self, new_name, _deadline=None):
@@ -1135,12 +1144,13 @@ class Collection(object):
     def map_reduce(self, map, reduce, full_response=False, **kwargs):
         params = {"map": map, "reduce": reduce}
         params.update(**kwargs)
+
         def on_ok(raw):
             if full_response:
                 return raw
             return raw.get("results")
-        return self._database.command("mapreduce", self._collection_name, **params)\
-                .addCallback(on_ok)
+        return self._database.command(
+            "mapreduce", self._collection_name, **params).addCallback(on_ok)
 
     @timeout
     def find_and_modify(self, query=None, update=None, upsert=False, **kwargs):
@@ -1202,8 +1212,9 @@ class Collection(object):
 
         no_obj_error = "No matching object found"
 
-        return self._database.command(cmd, allowable_errors=[no_obj_error], _deadline=_deadline)\
-                .addCallback(lambda result: result.get("value"))
+        return self._database.command(
+            cmd, allowable_errors=[no_obj_error], _deadline=_deadline
+        ).addCallback(lambda result: result.get("value"))
 
     @timeout
     def find_one_and_delete(self, filter, projection=None, sort=None, _deadline=None):
@@ -1299,7 +1310,6 @@ class Collection(object):
 
         return iterate(iterate, on_cmd_result).addCallback(on_all_done)
 
-
     def _execute_batch_command(self, command_type, documents, ordered):
         assert command_type in _OP_MAP
 
@@ -1327,7 +1337,7 @@ class Collection(object):
 
             actual_write_concern = self.write_concern
             if ordered and self.write_concern.acknowledged is False:
-                actual_write_concern = WriteConcern(w = 1)
+                actual_write_concern = WriteConcern(w=1)
 
             batches = self._generate_batch_commands(self._collection_name, _COMMANDS[command_type],
                                                     _OP_MAP[command_type], documents, ordered,

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -1126,8 +1126,10 @@ class Collection(object):
             if full_response:
                 return raw
             return raw.get("result")
-        return self._database.command("aggregate", self._collection_name, pipeline = pipeline,
-                                      _deadline = _deadline).addCallback(on_ok)
+        return self._database.command(
+            "aggregate", self._collection_name, pipeline=pipeline,
+            _deadline=_deadline, cursor={"batchSize": 0}
+        ).addCallback(on_ok)
 
     @timeout
     def map_reduce(self, map, reduce, full_response=False, **kwargs):
@@ -1361,7 +1363,7 @@ class Collection(object):
                 def on_fail(failure):
                     failure.trap(defer.FirstError)
                     failure.value.subFailure.raiseException()
-                    
+
                 if self.write_concern.acknowledged and not ordered:
                     return defer.gatherResults(all_responses, consumeErrors=True)\
                         .addErrback(on_fail)

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -1120,7 +1120,7 @@ class Collection(object):
                                       **params).addCallback(lambda result: result.get("values"))
 
     @timeout
-    def aggregate(self, pipeline, full_response=False, _deadline=None):
+    def aggregate(self, pipeline, full_response=False, initial_batch_size=None, _deadline=None):
         """aggregate(pipeline, full_response=False)"""
 
         def on_ok(raw, data=None):
@@ -1142,9 +1142,14 @@ class Collection(object):
             )
             return next_reply.addCallback(on_ok, data)
 
+        if initial_batch_size is None:
+            cursor = {}
+        else:
+            cursor = {"batchSize": initial_batch_size}
+
         return self._database.command(
             "aggregate", self._collection_name, pipeline=pipeline,
-            _deadline=_deadline, cursor={}
+            _deadline=_deadline, cursor=cursor
         ).addCallback(on_ok)
 
     @timeout


### PR DESCRIPTION
Mongo 3.6 requires either an `explain` or a `cursor` option with the `aggregate` command. This update adds a `cursor` option with a default initial batch size of `0` (which allows the cursor to quickly return without doing work in case of an error -- see [Mongo docs](https://docs.mongodb.com/manual/reference/method/db.collection.aggregate/#example-aggregate-method-initial-batch-size)

Without this, any `aggregate` query will fail in Mongo 3.6+

This patch gets it back running again, but does not expose the `cursor` option to the calling command. Should it provide a default and also allow that option to be set? The cursor option is a dictionary, but looking at the docs, it _appears_ that it only has one key -- `batchSize`, so I would think we could just expose `initial_batch_size` as a keyword argument, and set it to some reasonable default.