### PR TITLE
Added support for batchsize parameter in collection.py/

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -2,13 +2,6 @@ Changelog
 =========
 
 
-Release UNVERSIONED
----------------------------
-
-Features
-^^^^^^^^
-
-- Added support for paged request: implementation of batchsize parameter in Collection.find_with_cursor
 
 
 Release 18.1.0 (UNRELEASED)
@@ -27,6 +20,11 @@ Bugfixes
 ^^^^^^^^
 
 - Fixed compatibility with PyMongo 3.6
+
+Features
+^^^^^^^^
+
+- Added support for paged request: implementation of batchsize parameter in Collection.find_with_cursor
 
 
 Release 17.1.0 (2017-08-11)

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+
+Release UNVERSIONED
+---------------------------
+
+Features
+^^^^^^^^
+
+- Added support for paged request: implementation of batchsize parameter in Collection.find_with_cursor
+
+
 Release 18.1.0 (UNRELEASED)
 ---------------------------
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -17,10 +17,10 @@ from __future__ import absolute_import, division
 
 from bson import BSON
 from twisted.trial import unittest
-from twisted.python.compat import unicode
-import mock
-from tests.utils import SingleCollectionTest
 from twisted.internet import defer
+from twisted.python.compat import unicode
+
+from tests.utils import SingleCollectionTest
 
 from txmongo.protocol import MongoClientProtocol, MongoDecoder, Insert, Query, \
     KillCursors, Getmore, Update, Delete, UPDATE_MULTI, UPDATE_UPSERT, \

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -95,6 +95,17 @@ class TestMongoQueries(SingleCollectionTest):
         self.assertEqual(total, 150)
 
     @defer.inlineCallbacks
+    def test_FindWithCursorBatchsize(self):
+        yield self.coll.insert([{'v': i} for i in range(140)], safe=True)
+
+        docs, d = yield self.coll.find_with_cursor(batchsize=50)
+        lengths = [] 
+        while docs:
+            lengths.append(len(docs))
+            docs, d = yield d
+        self.assertEqual(lengths, [50,50,40])
+
+    @defer.inlineCallbacks
     def test_LargeData(self):
         yield self.coll.insert([{'v': ' '*(2**19)} for _ in range(4)], safe=True)
         res = yield self.coll.find()

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -98,12 +98,37 @@ class TestMongoQueries(SingleCollectionTest):
     def test_FindWithCursorBatchsize(self):
         yield self.coll.insert([{'v': i} for i in range(140)], safe=True)
 
-        docs, d = yield self.coll.find_with_cursor(batchsize=50)
+        docs, d = yield self.coll.find_with_cursor(batch_size=50)
         lengths = [] 
         while docs:
             lengths.append(len(docs))
             docs, d = yield d
         self.assertEqual(lengths, [50,50,40])
+
+    @defer.inlineCallbacks
+    def test_FindWithCursorBatchsizeLimit(self):
+        yield self.coll.insert([{'v': i} for i in range(140)], safe=True)
+
+        docs, d = yield self.coll.find_with_cursor(batch_size=50,limit=10)
+        lengths = [] 
+        while docs:
+            lengths.append(len(docs))
+            docs, d = yield d
+        self.assertEqual(lengths, [10])
+
+    @defer.inlineCallbacks
+    def test_FindWithCursorZeroBatchsize(self):
+        yield self.coll.insert([{'v': i} for i in range(140)], safe=True)
+
+        docs, d = yield self.coll.find_with_cursor(batch_size=0)
+        lengths = [] 
+        while docs:
+            lengths.append(len(docs))
+            docs, d = yield d
+        print(lengths)
+        self.assertEqual(lengths, [101,39])
+
+
 
     @defer.inlineCallbacks
     def test_LargeData(self):

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -367,7 +367,7 @@ class Collection(object):
 
     @timeout
     def find_with_cursor(self, *args, **kwargs):
-        """find_with_cursor(filter=None, projection=None, skip=0, limit=0, sort=None, batchSize=0, **kwargs)
+        """find_with_cursor(filter=None, projection=None, skip=0, limit=0, sort=None, batch_size=0, **kwargs)
 
         Find documents in a collection and return them in one batch at a time.
 
@@ -389,7 +389,7 @@ class Collection(object):
         new_kwargs = self._find_args_compat(*args, **kwargs)
         return self.__real_find_with_cursor(**new_kwargs)
 
-    def __real_find_with_cursor(self, filter=None, projection=None, skip=0, limit=0, sort=None, batchsize=0,**kwargs):
+    def __real_find_with_cursor(self, filter=None, projection=None, skip=0, limit=0, sort=None, batch_size=0,**kwargs):
         
         if filter is None:
             filter = SON()
@@ -402,7 +402,7 @@ class Collection(object):
             raise TypeError("TxMongo: skip must be an instance of int.")
         if not isinstance(limit, int):
             raise TypeError("TxMongo: limit must be an instance of int.")
-        if not isinstance(batchsize, int):
+        if not isinstance(batch_size, int):
             raise TypeError("TxMongo: batchsize must be an instance of int.")
 
         projection = self._normalize_fields_projection(projection)
@@ -417,10 +417,10 @@ class Collection(object):
 
             check_deadline(kwargs.pop("_deadline", None))
 
-            if batchsize and limit:
-                n_to_return = min(batchsize,limit)
-            elif batchsize:
-                n_to_return = batchsize
+            if batch_size and limit:
+                n_to_return = min(batch_size,limit)
+            elif batch_size:
+                n_to_return = batch_size
             else:
                 n_to_return = limit
 
@@ -451,13 +451,13 @@ class Collection(object):
             out = [document.decode(codec_options=options) for document in documents[:docs_count]]
 
             if reply.cursor_id:
-                # please note that this will not be the case if batchsize = 1
+                # please note that this will not be the case if batch_size = 1
                 # it is documented (parameter numberToReturn for OP_QUERY)
                 # https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#wire-op-query 
                 if limit == 0:
                     to_fetch = 0  # no limit
-                    if batchsize:
-                      to_fetch = batchsize
+                    if batch_size:
+                      to_fetch = batch_size
                 elif limit < 0:
                     # We won't actually get here because MongoDB won't
                     # create cursor when limit < 0
@@ -466,8 +466,8 @@ class Collection(object):
                     to_fetch = limit - fetched
                     if to_fetch <= 0:
                         to_fetch = None  # close cursor
-                    elif batchsize:
-                        to_fetch = min(batchsize,to_fetch)
+                    elif batch_size:
+                        to_fetch = min(batch_size,to_fetch)
 
                 if to_fetch is None:
                     protocol.send_KILL_CURSORS(KillCursors(cursors=[reply.cursor_id]))

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -403,7 +403,7 @@ class Collection(object):
         if not isinstance(limit, int):
             raise TypeError("TxMongo: limit must be an instance of int.")
         if not isinstance(batch_size, int):
-            raise TypeError("TxMongo: batchsize must be an instance of int.")
+            raise TypeError("TxMongo: batch_size must be an instance of int.")
 
         projection = self._normalize_fields_projection(projection)
 

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -1139,14 +1139,37 @@ class Collection(object):
                                       **params).addCallback(lambda result: result.get("values"))
 
     @timeout
-    def aggregate(self, pipeline, full_response=False, _deadline=None):
+    def aggregate(self, pipeline, full_response=False, initial_batch_size=None, _deadline=None):
         """aggregate(pipeline, full_response=False)"""
-        def on_ok(raw):
-            if full_response:
-                return raw
-            return raw.get("result")
-        return self._database.command("aggregate", self._collection_name, pipeline = pipeline,
-                                      _deadline = _deadline).addCallback(on_ok)
+
+        def on_ok(raw, data=None):
+            if data is None:
+                data = []
+            if "firstBatch" in raw["cursor"]:
+                batch = raw["cursor"]["firstBatch"]
+            else:
+                batch = raw["cursor"].get("nextBatch", [])
+            data += batch
+            if raw["cursor"]["id"] == 0:
+                if full_response:
+                    raw["result"] = data
+                    return raw
+                return data
+            next_reply = self._database.command(
+                "getMore", collection=self._collection_name,
+                getMore=raw["cursor"]["id"]
+            )
+            return next_reply.addCallback(on_ok, data)
+
+        if initial_batch_size is None:
+            cursor = {}
+        else:
+            cursor = {"batchSize": initial_batch_size}
+
+        return self._database.command(
+            "aggregate", self._collection_name, pipeline=pipeline,
+            _deadline=_deadline, cursor=cursor
+        ).addCallback(on_ok)
 
     @timeout
     def map_reduce(self, map, reduce, full_response=False, **kwargs):
@@ -1380,7 +1403,7 @@ class Collection(object):
                 def on_fail(failure):
                     failure.trap(defer.FirstError)
                     failure.value.subFailure.raiseException()
-                    
+
                 if self.write_concern.acknowledged and not ordered:
                     return defer.gatherResults(all_responses, consumeErrors=True)\
                         .addErrback(on_fail)


### PR DESCRIPTION
Added optional batchsize parameter in find_with_cursor (collection.py)
Related: cursors may time out (cursorTimeout ...) Added handling for CursorNotFound in handle_REPLY (protocol.py) 
Added test for batchsize: 
    test_FindWithCursorBatchsize (tests.test_queries.TestMongoQueries)
   test_FindWithCursorBatchsize ... ok

The proposed changed builds on the default behavior of Collection.find_with_cursor. 
When issuing the initial request 101 documents are returned, the remainder of the documents are returned upon the next iteration (yielding on the deferred returned in the initial request)

This change allows one to configure the number of documents to be returned per iteration.
It helps heavily loaded clients to control their resources, when working with large collections.

An alternative approach would be to control the documents to be returned by playing with the parameters "skip" and "limit" in Collection.find, which is much less efficient than using the proposed change and puts a heavier burden on mongodb.