### PR TITLE
Changelog entry for PR #226 moved to 18.1.0 UNRELEASED

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -12,6 +12,11 @@ Bugfixes
 
 - Fixed compatibility of `Collection.aggregate()` with PyMongo 3.6
 
+Features
+^^^^^^^^
+
+- Added support for paged request: implementation of batchsize parameter in Collection.find_with_cursor
+
 
 Release 18.0.0 (2018-01-02)
 ---------------------------
@@ -20,11 +25,6 @@ Bugfixes
 ^^^^^^^^
 
 - Fixed compatibility with PyMongo 3.6
-
-Features
-^^^^^^^^
-
-- Added support for paged request: implementation of batchsize parameter in Collection.find_with_cursor
 
 
 Release 17.1.0 (2017-08-11)


### PR DESCRIPTION
Changelog entry for #226 seems to be mistakenly added to already released 18.0.0 instead of pending 18.1.0 release.

See https://github.com/twisted/txmongo/pull/226#issuecomment-373710445