### PR TITLE
Do not reuse exception instances

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -11,6 +11,7 @@ Bugfixes
 ^^^^^^^^
 
 - Fixed compatibility of `Collection.aggregate()` with PyMongo 3.6
+- AutoReconnect exceptions may give invalid stack traces when not handled
 
 
 Release 18.0.0 (2018-01-02)

--- a/txmongo/protocol.py
+++ b/txmongo/protocol.py
@@ -323,16 +323,14 @@ class MongoProtocol(MongoServerProtocol, MongoClientProtocol):
         # too late.
         self.factory.setInstance(None, reason)
 
-        auto_reconnect = AutoReconnect("TxMongo lost connection to MongoDB.")
-
         if self.__deferreds:
             deferreds, self.__deferreds = self.__deferreds, {}
             for df in deferreds.values():
-                df.errback(auto_reconnect)
+                df.errback(AutoReconnect("TxMongo lost connection to MongoDB."))
         deferreds, self.__connection_ready = self.__connection_ready, []
         if deferreds:
             for df in deferreds:
-                df.errback(auto_reconnect)
+                df.errback(AutoReconnect("TxMongo lost connection to MongoDB."))
 
         protocol.Protocol.connectionLost(self, reason)
 


### PR DESCRIPTION
`MongoProtocol.connectionLost` uses single shared `AutoReconnect` instance to fail many different Deferreds. It took me a day of debugging and not a single gray hair to figure out that logged stack traces of unhandled failures may be very weird in this case.

Proof:

```python
import sys
from twisted.internet.defer import Deferred, inlineCallbacks
from twisted.python import log

log.startLogging(sys.stdout)

@inlineCallbacks
def task1(d):
    try:
        yield d
    except ZeroDivisionError as e:
        print('task cought')

@inlineCallbacks
def task2(d):
    yield d

d1 = Deferred()
d2 = Deferred()

task1(d1)
task2(d2)

error = ZeroDivisionError('boom')
d1.errback(error)
d2.errback(error)
```

This prints:

```
2018-03-16 16:20:28+0300 [-] Log opened.
2018-03-16 16:20:28+0300 [-] task cought
2018-03-16 16:20:28+0300 [-] Unhandled error in Deferred:
2018-03-16 16:20:28+0300 [-] Unhandled Error
        Traceback (most recent call last):
          File "/home/ilya/txmongo/venv3/lib/python3.6/site-packages/twisted/internet/defer.py", line 500, in errback
            self._startRunCallbacks(fail)
          File "/home/ilya/txmongo/venv3/lib/python3.6/site-packages/twisted/internet/defer.py", line 567, in _startRunCallbacks
            self._runCallbacks()
          File "/home/ilya/txmongo/venv3/lib/python3.6/site-packages/twisted/internet/defer.py", line 653, in _runCallbacks
            current.result = callback(current.result, *args, **kw)
          File "/home/ilya/txmongo/venv3/lib/python3.6/site-packages/twisted/internet/defer.py", line 1442, in gotResult
            _inlineCallbacks(r, g, deferred)
        --- <exception caught here> ---
          File "/home/ilya/txmongo/venv3/lib/python3.6/site-packages/twisted/internet/defer.py", line 1384, in _inlineCallbacks
            result = result.throwExceptionIntoGenerator(g)
          File "/home/ilya/txmongo/venv3/lib/python3.6/site-packages/twisted/python/failure.py", line 408, in throwExceptionIntoGenerator
            return g.throw(self.type, self.value, self.tb)
          File "exc-demo.py", line 17, in task2
            yield d
          File "exc-demo.py", line 11, in task1
            yield d
        builtins.ZeroDivisionError: boom
```

Note that stack trace points out on that `task1` is the source of exception although it was successfully caught there. Add some more complexity and twisted callback chains in between and you will have fun time realizing where exception is from :)