### PR TITLE
Fixing KeyError when bulk operation is interrupted (for example by failover)

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -2,6 +2,14 @@ Changelog
 =========
 
 
+Release 18.2.0 (UNRELEASED)
+---------------------------
+
+Bugfixes
+^^^^^^^^
+
+- In combination with PyMongo 3.6.0 `bulk_write` might sometimes raise
+  KeyError when bulk operation was interrupted (by failover, for example)
 
 
 Release 18.1.0 (2018-03-21)

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -14,6 +14,7 @@ from bson.codec_options import CodecOptions
 from pymongo.bulk import _Bulk, _COMMANDS, _merge_command
 from pymongo.errors import InvalidName, BulkWriteError, InvalidOperation, OperationFailure, DuplicateKeyError, \
     WriteError, WTimeoutError, WriteConcernError
+from pymongo.helpers import _check_command_response
 from pymongo.message import _OP_MAP, _INSERT
 from pymongo.results import InsertOneResult, InsertManyResult, UpdateResult, \
     DeleteResult, BulkWriteResult
@@ -1350,6 +1351,7 @@ class Collection(object):
 
             def accumulate_result(reply, idx_offset):
                 result = reply.documents[0].decode()
+                _check_command_response(result)
                 results.append((idx_offset, result))
                 return result
 


### PR DESCRIPTION
If Bulk operation is interrupted (by failover, by network failure, ...) current version of txmongo with combination of PyMongo 3.6.0 raises KeyError from `coll.bulk_write`. This is because we are calling `pymongo.bulk._merge_command` without checking it for being proper bulk response.