### PR TITLE
Tests fixed with MongoDB 3.6

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -10,6 +10,7 @@ Bugfixes
 
 - In combination with PyMongo 3.6.0 `bulk_write` might sometimes raise
   KeyError when bulk operation was interrupted (by failover, for example)
+- Compatibility with PyMongo 3.7
 
 
 Release 18.1.0 (2018-03-21)

--- a/tests/mongod.py
+++ b/tests/mongod.py
@@ -68,7 +68,6 @@ class Mongod(object):
                 b"--noprealloc", b"--nojournal",
                 b"--smallfiles", b"--nssize", b"1",
                 b"--oplogSize", b"1",
-                b"--nohttpinterface",
         ]
         if self.auth: args.append(b"--auth")
         if self.replset: args.extend([b"--replSet", self.replset])

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -1,6 +1,6 @@
 from bson import BSON
 from pymongo import InsertOne
-from pymongo.errors import BulkWriteError, OperationFailure
+from pymongo.errors import BulkWriteError, OperationFailure, NotMasterError
 from pymongo.operations import UpdateOne, DeleteOne, UpdateMany, ReplaceOne
 from pymongo.results import BulkWriteResult
 from pymongo.write_concern import WriteConcern
@@ -242,4 +242,4 @@ class TestOperationFailure(SingleCollectionTest):
         with patch('txmongo.protocol.MongoProtocol.send_QUERY', side_effect=fake_send_query):
             yield self.assertFailure(
                     self.coll.bulk_write([UpdateOne({}, {'$set': {'x': 42}}, upsert=True)], ordered=True),
-                    OperationFailure)
+                    OperationFailure, NotMasterError)

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -415,7 +415,8 @@ class TestCommand(SingleCollectionTest):
             "delete", "mycol", check=True,
             allowable_errors=[
                 "missing deletes field",
-                "The deletes option is required to the delete command."
+                "The deletes option is required to the delete command.",
+                "BSON field 'delete.deletes' is missing but a required field"
             ]
         )
         self.assertFalse(result["ok"])

--- a/txmongo/protocol.py
+++ b/txmongo/protocol.py
@@ -15,7 +15,9 @@ decoding as well as Exception types, when applicable.
 
 from __future__ import absolute_import, division
 import base64
-from bson import BSON, SON, Binary
+import hashlib
+
+from bson import BSON, SON, Binary, PY3
 from collections import namedtuple
 from hashlib import sha1
 import hmac
@@ -28,6 +30,51 @@ import struct
 from twisted.internet import defer, protocol, error
 from twisted.python import failure, log
 from twisted.python.compat import unicode
+
+
+if PY3:
+    _from_bytes = int.from_bytes
+    _to_bytes = int.to_bytes
+else:
+    def _from_bytes(value, dummy, _int=int, _hexlify=_hexlify):
+        """An implementation of int.from_bytes for python 2.x."""
+        return _int(_hexlify(value), 16)
+
+
+    def _to_bytes(value, length, dummy, _unhexlify=_unhexlify):
+        """An implementation of int.to_bytes for python 2.x."""
+        fmt = '%%0%dx' % (2 * length,)
+        return _unhexlify(fmt % value)
+
+
+try:
+    # The fastest option, if it's been compiled to use OpenSSL's HMAC.
+    from backports.pbkdf2 import pbkdf2_hmac as _hi
+except ImportError:
+    try:
+        # Python 2.7.8+, or Python 3.4+.
+        from hashlib import pbkdf2_hmac as _hi
+    except ImportError:
+
+        def _hi(hash_name, data, salt, iterations):
+            """A simple implementation of PBKDF2-HMAC."""
+            mac = hmac.HMAC(data, None, getattr(hashlib, hash_name))
+
+            def _digest(msg, mac=mac):
+                """Get a digest for msg."""
+                _mac = mac.copy()
+                _mac.update(msg)
+                return _mac.digest()
+
+            from_bytes = _from_bytes
+            to_bytes = _to_bytes
+
+            _u1 = _digest(salt + b'\x00\x00\x00\x01')
+            _ui = from_bytes(_u1, 'big')
+            for _ in range(iterations - 1):
+                _u1 = _digest(_u1)
+                _ui ^= from_bytes(_u1, 'big')
+            return to_bytes(_ui, mac.digest_size, 'big')
 
 
 INT_MAX = 2147483647
@@ -467,9 +514,9 @@ class MongoProtocol(MongoServerProtocol, MongoClientProtocol):
             raise MongoAuthenticationError("TxMongo: server returned an invalid nonce.")
 
         without_proof = b"c=biws,r=" + rnonce
-        salted_pass = auth._hi(auth._password_digest(username, password).encode("utf-8"),
-                               base64.standard_b64decode(salt),
-                               iterations)
+        salted_pass = _hi('sha1', auth._password_digest(username, password).encode("utf-8"),
+                          base64.standard_b64decode(salt),
+                          iterations)
         client_key = hmac.HMAC(salted_pass, b"Client Key", sha1).digest()
         stored_key = sha1(client_key).digest()
         auth_msg = b','.join((first_bare, server_first, without_proof))

--- a/txmongo/protocol.py
+++ b/txmongo/protocol.py
@@ -36,6 +36,8 @@ if PY3:
     _from_bytes = int.from_bytes
     _to_bytes = int.to_bytes
 else:
+    from binascii import (hexlify as _hexlify, unhexlify as _unhexlify)
+
     def _from_bytes(value, dummy, _int=int, _hexlify=_hexlify):
         """An implementation of int.from_bytes for python 2.x."""
         return _int(_hexlify(value), 16)


### PR DESCRIPTION
Fixing some test failures when running against MongoDB 3.6. TxMongo works fine with 3.6, this issue only affects testing code that hardcodes some error message texts and other internal MongoDB stuff from 3.4. No user-visible changes here.

This PR is based on #233 and includes its commits, so it should be merged only after that.