### PR TITLE
Allow collection options to be passed only via kwargs

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Release 18.3.0 (UNRELEASED)
+---------------------------
+
+Features
+^^^^^^^^
+
+- Allow passing only kwargs to `Database.create_collection()`
+
 
 Release 18.2.0 (2018-07-19)
 ---------------------------

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -336,6 +336,15 @@ class TestCreateCollection(unittest.TestCase):
         yield self.conn.disconnect()
 
     @defer.inlineCallbacks
+    def test_WithOptions(self):
+        coll = yield self.db.create_collection("opttest", capped=True, size=4096)
+        self.assertTrue(isinstance(coll, Collection))
+
+        opts = yield coll.options()
+        self.assertEqual(opts["capped"], True)
+        self.assertEqual(opts["size"], 4096)
+
+    @defer.inlineCallbacks
     def test_Fail(self):
         # Not using assertFailure() here because it doesn't wait until deferred is
         # resolved or failed but there was a bug that made deferred hang forever

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -78,6 +78,10 @@ class Database(object):
         collection = Collection(self, name, write_concern=write_concern,
                                 codec_options=codec_options)
 
+        if options is None and kwargs:
+            options = kwargs
+            kwargs = {}
+
         if options:
             if "size" in options:
                 options["size"] = float(options["size"])


### PR DESCRIPTION
This is in line with the pymongo [behavior][0], and will make it easier to migrate code from pymongo to txmongo.

[0]: https://github.com/mongodb/mongo-python-driver/blob/3.7.2/pymongo/database.py#L304