### PR TITLE
support for mongodb+srv:// uri scheme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ setup(
     keywords=["mongo", "mongodb", "pymongo", "gridfs", "txmongo"],
     packages=["txmongo", "txmongo._gridfs"],
     install_requires=["twisted>=14.0", "pymongo>=3.0"],
+    extras_require={
+        'srv': ['pymongo[srv]>=3.6'],
+    },
     license="Apache License, Version 2.0",
     include_package_data=True,
     test_suite="nose.collector",

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -251,7 +251,7 @@ class ConnectionPool(object):
         assert isinstance(pool_size, int)
         assert pool_size >= 1
 
-        if not uri.startswith("mongodb://"):
+        if not uri.startswith("mongodb://") and not uri.startswith("mongodb+srv://"):
             uri = "mongodb://" + uri
 
         self.__uri = parse_uri(uri)


### PR DESCRIPTION
As reported in #247 we didn't support monogdb+srv:// although PyMongo supports it since 3.6.

This PR adds mongodb+srv scheme with "extra" `[srv]` dependency because corresponding feature in PyMongo requires same extra dependency too.

So to have mongodb+srv working txmongo should be installed like this: `pip install txmongo[srv]`.