### PR TITLE
new-style wire protocol implementation for find*() methods

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import, division
 
 from twisted.trial import unittest
 from twisted.internet import defer
+
 import txmongo
 import txmongo.filter as qf
 from pymongo.errors import OperationFailure
@@ -110,6 +111,9 @@ class TestMongoFilters(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_Snapshot(self):
+        ismaster = yield self.db.command('ismaster')
+        if ismaster['maxWireVersion'] >= 7:
+            raise unittest.SkipTest('snapshot option is only for MongoDB <=3.6')
         yield self.__test_simple_filter(qf.snapshot(), "snapshot", True)
 
     @defer.inlineCallbacks

--- a/tests/test_replicaset.py
+++ b/tests/test_replicaset.py
@@ -188,7 +188,7 @@ class TestReplicaSet(unittest.TestCase):
 
             yield conn.db.coll.insert({'x': 42}, safe=True)
 
-            yield self.__mongod[0].stop()
+            yield self.__mongod[0].kill(signal.SIGSTOP)
 
             while True:
                 try:
@@ -200,6 +200,7 @@ class TestReplicaSet(unittest.TestCase):
                     pass
 
         finally:
+            yield self.__mongod[0].kill(signal.SIGCONT)
             yield conn.disconnect()
             self.flushLoggedErrors(AutoReconnect)
 
@@ -213,7 +214,7 @@ class TestReplicaSet(unittest.TestCase):
 
             yield conn.db.coll.insert({'x': 42}, safe=True)
 
-            yield self.__mongod[0].stop()
+            yield self.__mongod[0].kill(signal.SIGSTOP)
 
             while True:
                 try:
@@ -225,6 +226,7 @@ class TestReplicaSet(unittest.TestCase):
                     pass
 
         finally:
+            yield self.__mongod[0].kill(signal.SIGCONT)
             yield conn.disconnect()
             self.flushLoggedErrors(AutoReconnect)
 


### PR DESCRIPTION
Starting from maxWireVersion=4 (v3.2) MongoDB migrated to new implementation of CRUD methods based on [commands](https://docs.mongodb.com/manual/reference/command/nav-crud/) commands instead of `OP_*` low-level message codes.

We already support new-style commands for insert, update, replace and delete (when called as `*_one`/`*_many`). This patch adds support for find*() methods too and uses it by default if maxWireVersion ≥ 4.

This also (hopefully) makes txmongo compatible with Azure's Cosmos DB that only supports new-style API.

In future this will allow us to support sessions and transactions because it only supported for new-style queries.