### PR TITLE
Don't test against latest Twisted with Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,12 @@ matrix:
       env: TOX_ENV=twtrunk
     - python: pypy3
       env: TOX_ENV=twtrunk
+      
+  exclude:
+    - python: 2.7
+      env: TOX_ENV=twlatest
+    - python: 2.7
+      env: TOX_ENV=twtrunk
 
   include:
     - python: 3.5


### PR DESCRIPTION
Current versions of Twisted dropped support for 2.7.

Actually, we need to update Twisted versions list in .travis-ci.yml, leaving it to the next PR.