### PR TITLE
Fix retrieving error messages

### DIFF
--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -15,7 +15,7 @@ from twisted.python import log
 from twisted.python.compat import StringType
 from txmongo.database import Database
 from txmongo.protocol import MongoProtocol, Query
-from txmongo.utils import timeout
+from txmongo.utils import timeout, get_err
 
 DEFAULT_MAX_BSON_SIZE = 16777216
 DEFAULT_MAX_WRITE_BATCH_SIZE = 1000
@@ -103,7 +103,7 @@ class _Connection(ReconnectingClientFactory):
         # Make sure the command was successful.
         if not config.get("ok"):
             code = config.get("code")
-            msg = "TxMongo: " + config.get("err", "Unknown error")
+            msg = "TxMongo: " + get_err(config, "Unknown error")
             raise OperationFailure(msg, code)
 
         # Check that the replicaSet matches.

--- a/txmongo/protocol.py
+++ b/txmongo/protocol.py
@@ -30,6 +30,7 @@ import struct
 from twisted.internet import defer, protocol, error
 from twisted.python import failure, log
 from twisted.python.compat import unicode
+from txmongo.utils import get_err
 
 
 if PY3:
@@ -449,7 +450,7 @@ class MongoProtocol(MongoServerProtocol, MongoClientProtocol):
             assert len(reply.documents) == 1
 
             document = reply.documents[0].decode()
-            err = document.get("err", None)
+            err = get_err(document, None)
             code = document.get("code", None)
 
             if err is not None:

--- a/txmongo/utils/__init__.py
+++ b/txmongo/utils/__init__.py
@@ -56,3 +56,9 @@ def timeout(func):
 def check_deadline(_deadline):
     if _deadline is not None and _deadline < time():
         raise TimeExceeded("TxMongo: now '{0}', deadline '{1}'".format(time(), _deadline))
+
+
+def get_err(document, default=None):
+    err = document.get("err", None) or document.get("codeName", None)
+    errmsg = document.get("errmsg", None)
+    return ": ".join(filter(None, (err, errmsg))) or default


### PR DESCRIPTION
Hi.

As is reported in #236, error messages in exceptions raised by txmongo are sometimes ambiguous.

The reason is that txmongo only picks the field `err`, which is not present all the time even if there are actual errors. I cannot find a detailed and exhaustive documentation for all possible fields (there are some related documentations, but for example, none of them formally documents the existence of the field `codeName`). But at least, there are `codeName`, and `errmsg` in recent MongoDB versions.

This PR is going to fix the problem by fall backing to `codeName` and `errmsg` when `err` is not present. It picks any of the three fields whichever is present. 

It should partially fix #236, giving a detailed error message:
`TxMongo: AtlasError: no SNI name sent, make sure using a MongoDB 3.4+ driver/shell.`