### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/docs/source/status.rst
+++ b/docs/source/status.rst
@@ -2,7 +2,7 @@ Status and History
 ==================
 
 TxMongo was created by `Alexandre Fiori <https://github.com/fiorix>`_ who developed it during the years 2009-2010.
-From 2010 and onwards mainly bug fixes were added, as Alexandre entered maintance mode with many contributions being made by others.
+From 2010 and onwards mainly bug fixes were added, as Alexandre entered maintenance mode with many contributions being made by others.
 Development picked back up in 2014 by `Bret Curtis <https://github.com/psi29a>`_ with Alexandre's consent and was migrated to Twisted where it is a first-party Twisted library.
 TxMongo can be found here:
 

--- a/examples/deferreds/insert.py
+++ b/examples/deferreds/insert.py
@@ -31,7 +31,7 @@ def getCollection(db, collName):
 def insertData(coll):
     print "inserting data..."
     # insert some data, building a deferred list so that we can later check
-    # the succes or failure of each deferred result
+    # the success or failure of each deferred result
     deferreds = []
     for x in range(10000):
         d = coll.insert({"something":x*time.time()}, safe=True)

--- a/txmongo/_gridfs/__init__.py
+++ b/txmongo/_gridfs/__init__.py
@@ -45,7 +45,7 @@ class GridFS(object):
         .. note::
 
             Instantiating a GridFS object will implicitly create it indexes.
-            This could leads to errors if the underlaying connection is closed
+            This could leads to errors if the underlying connection is closed
             before the indexes creation request has returned. To avoid this you
             should use the defer returned by :meth:`GridFS.indexes_created`.
 

--- a/txmongo/_gridfs/grid_file.py
+++ b/txmongo/_gridfs/grid_file.py
@@ -276,10 +276,10 @@ class GridIn(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Support for the context manager protocol.
 
-        Close the file and allow exceptions to propogate.
+        Close the file and allow exceptions to propagate.
         """
         self.close()
-        return False  # untrue will propogate exceptions
+        return False  # untrue will propagate exceptions
 
 
 class GridOut(object):


### PR DESCRIPTION
There are small typos in:
- docs/source/status.rst
- examples/deferreds/insert.py
- txmongo/_gridfs/__init__.py
- txmongo/_gridfs/grid_file.py

Fixes:
- Should read `propagate` rather than `propogate`.
- Should read `underlying` rather than `underlaying`.
- Should read `success` rather than `succes`.
- Should read `maintenance` rather than `maintance`.

Closes #275