### PR TITLE
Deprecation warnings

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Release UPCOMING (yyyy-mm-dd)
+-----------------------------
+
+API Changes
+^^^^^^^^^^^
+
+- PyMongo 4+ is now supported. If you will migrate from PyMongo 3 to PyMongo 4, please be sure
+  to check their PyMongo's guide because newer version has a number of incompatible changes.
+
+
 Release 23.0.0 (2023-01-29)
 ---------------------------
 

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,12 +1,13 @@
 Changelog
 =========
 
-Release UPCOMING (yyyy-mm-dd)
------------------------------
+Release 24.0.0 (2024-09-18)
+---------------------------
 
 API Changes
 ^^^^^^^^^^^
 
+- This is the last release that supports Python <3.8 and MongoDB <4.0
 - PyMongo 4+ is now supported. If you will migrate from PyMongo 3 to PyMongo 4, please be sure
   to check their PyMongo's guide because newer version has a number of incompatible changes.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,14 +51,14 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'TxMongo'
-copyright = '2021, Alexandre Fiori, Bret Curtis, Ilya Skriblovsky'
+copyright = '2024, Alexandre Fiori, Bret Curtis, Ilya Skriblovsky'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 # The short X.Y version.
-version = '23.0.0'
+version = '24.0.0'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/python-txmongo.spec
+++ b/python-txmongo.spec
@@ -1,5 +1,5 @@
 Name:		python-txmongo
-Version:	23.0.0
+Version:	24.0.0
 Release:	1%{?dist}
 Summary:	Twisted driver for MongoDB
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url="https://github.com/twisted/txmongo",
     keywords=["mongo", "mongodb", "pymongo", "gridfs", "txmongo"],
     packages=["txmongo", "txmongo._gridfs"],
-    install_requires=["twisted>=14.0", "pymongo>=3.0, <4.0"],
+    install_requires=["twisted>=14.0", "pymongo>=3.0, <5.0"],
     extras_require={
         'srv': ['pymongo[srv]>=3.6'],
     },

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="txmongo",
-    version="23.0.0",
+    version="24.0.0",
     description="Asynchronous Python driver for MongoDB <http://www.mongodb.org>",
     author="Alexandre Fiori, Bret Curtis",
     author_email="fiorix@gmail.com, psi29a@gmail.com",

--- a/tests/basic/test_bulk.py
+++ b/tests/basic/test_bulk.py
@@ -1,6 +1,6 @@
 from bson import BSON
 from pymongo import InsertOne
-from pymongo.errors import BulkWriteError, OperationFailure, NotMasterError
+from pymongo.errors import BulkWriteError, OperationFailure
 from pymongo.operations import UpdateOne, DeleteOne, UpdateMany, ReplaceOne
 from pymongo.results import BulkWriteResult
 from pymongo.write_concern import WriteConcern
@@ -9,6 +9,12 @@ from unittest.mock import patch
 
 from tests.utils import SingleCollectionTest
 from txmongo.protocol import Reply
+
+try:
+    from pymongo.errors import NotPrimaryError
+except ImportError:
+    # For pymongo < 3.12
+    from pymongo.errors import NotMasterError as NotPrimaryError
 
 
 class TestArgsValidation(SingleCollectionTest):
@@ -242,4 +248,4 @@ class TestOperationFailure(SingleCollectionTest):
         with patch('txmongo.protocol.MongoProtocol.send_QUERY', side_effect=fake_send_query):
             yield self.assertFailure(
                     self.coll.bulk_write([UpdateOne({}, {'$set': {'x': 42}}, upsert=True)], ordered=True),
-                    OperationFailure, NotMasterError)
+                    OperationFailure, NotPrimaryError)

--- a/tests/basic/test_write_concern.py
+++ b/tests/basic/test_write_concern.py
@@ -137,7 +137,7 @@ class TestWriteConcern(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_ConnectionUrlParams(self):
-        conn = ConnectionPool("mongodb://{0}:{1}/?w=2&j=true".format(mongo_host, mongo_port))
+        conn = ConnectionPool("mongodb://{0}:{1}/?w=2&journal=true".format(mongo_host, mongo_port))
         coll = conn.mydb.mycol
 
         try:

--- a/txmongo/__init__.py
+++ b/txmongo/__init__.py
@@ -3,6 +3,9 @@
 # Use of this source code is governed by the Apache License that can be
 # found in the LICENSE file.
 
+import sys
+import warnings
+
 from txmongo.database import Database
 from txmongo.protocol import MongoProtocol, Query
 from txmongo.connection import MongoConnection, MongoConnectionPool, lazyMongoConnection, \
@@ -16,3 +19,6 @@ assert MongoConnection
 assert MongoConnectionPool
 assert lazyMongoConnection
 assert lazyMongoConnectionPool
+
+if sys.version_info < (3, 8):
+    warnings.warn("Only Python 3.8+ will be supported in the next version of TxMongo", DeprecationWarning)

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -2,6 +2,8 @@
 # Use of this source code is governed by the Apache License that can be
 # found in the LICENSE file.
 
+import warnings
+
 from bson.codec_options import DEFAULT_CODEC_OPTIONS
 from pymongo.errors import AutoReconnect, ConfigurationError, OperationFailure
 from pymongo.read_preferences import ReadPreference
@@ -118,6 +120,10 @@ class _Connection(ReconnectingClientFactory):
 
         proto.set_wire_versions(config.get("minWireVersion", 0),
                                 config.get("maxWireVersion", 0))
+
+        # MongoDB < 4.0
+        if proto.max_wire_version < 7:
+            warnings.warn("MongoDB <4.0 support will be dropped in the next version of TxMongo", DeprecationWarning)
 
         # Track the other hosts in the replica set.
         hosts = config.get("hosts")

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -4,12 +4,13 @@
 
 from bson.codec_options import DEFAULT_CODEC_OPTIONS
 from pymongo.errors import AutoReconnect, ConfigurationError, OperationFailure
-from pymongo.uri_parser import parse_uri
 from pymongo.read_preferences import ReadPreference
+from pymongo.uri_parser import parse_uri
 from pymongo.write_concern import WriteConcern
 from twisted.internet import defer, reactor, task
 from twisted.internet.protocol import ReconnectingClientFactory, ClientFactory
 from twisted.python import log
+
 from txmongo.database import Database
 from txmongo.protocol import MongoProtocol, Query
 from txmongo.utils import timeout, get_err

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 from bson.son import SON
-from bson.codec_options import DEFAULT_CODEC_OPTIONS
+
 from txmongo.collection import Collection
 from txmongo.pymongo_internals import _check_command_response
 from txmongo.utils import timeout
@@ -53,10 +53,12 @@ class Database:
 
     @timeout
     def command(self, command, value=1, check=True, allowable_errors=None,
-                codec_options=DEFAULT_CODEC_OPTIONS, _deadline=None, **kwargs):
-        """command(command, value=1, check=True, allowable_errors=None, codec_options=DEFAULT_CODEC_OPTIONS)"""
+                codec_options=None, _deadline=None, **kwargs):
+        """command(command, value=1, check=True, allowable_errors=None, codec_options=None)"""
         if isinstance(command, (bytes, str)):
             command = SON([(command, value)])
+        if codec_options is None:
+            codec_options = self.__codec_options
         options = kwargs.copy()
         command.update(options)
 


### PR DESCRIPTION
I want to make TxMongo compatible with newer wire protocol of MongoDB 5.0+ (OP_MSG).

This would be much easier to do without supporting older protocols at the same time.

That's why I suggest to drop support of outdated and no longer supported version of Python and MongoDB. This will allow us to cleanup and simplify the codebase.

To do it nicely I suggest to release 23.0.0 with the only change of deprecation warnings when old Python or MongoDB are detected.

@psi29a what do you think about it?