### PR TITLE
PyMongo 4+ support

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+Release UPCOMING (yyyy-mm-dd)
+-----------------------------
+
+API Changes
+^^^^^^^^^^^
+
+- PyMongo 4+ is now supported. If you will migrate from PyMongo 3 to PyMongo 4, please be sure
+  to check their PyMongo's guide because newer version has a number of incompatible changes.
+
+
 Release 23.0.0 (2023-01-29)
 ---------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Twisted
-pymongo>=3.0
+pymongo>=3.0,<4.9
 -e .

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url="https://github.com/twisted/txmongo",
     keywords=["mongo", "mongodb", "pymongo", "gridfs", "txmongo"],
     packages=["txmongo", "txmongo._gridfs"],
-    install_requires=["twisted>=14.0", "pymongo>=3.0, <4.0"],
+    install_requires=["twisted>=14.0", "pymongo>=3.0, <5.0"],
     extras_require={
         'srv': ['pymongo[srv]>=3.6'],
     },

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url="https://github.com/twisted/txmongo",
     keywords=["mongo", "mongodb", "pymongo", "gridfs", "txmongo"],
     packages=["txmongo", "txmongo._gridfs"],
-    install_requires=["twisted>=14.0", "pymongo>=3.0, <5.0"],
+    install_requires=["twisted>=14.0", "pymongo>=3.0, <4.9"],
     extras_require={
         'srv': ['pymongo[srv]>=3.6'],
     },

--- a/tests/basic/test_bulk.py
+++ b/tests/basic/test_bulk.py
@@ -1,6 +1,6 @@
 from bson import BSON
 from pymongo import InsertOne
-from pymongo.errors import BulkWriteError, OperationFailure, NotMasterError
+from pymongo.errors import BulkWriteError, OperationFailure
 from pymongo.operations import UpdateOne, DeleteOne, UpdateMany, ReplaceOne
 from pymongo.results import BulkWriteResult
 from pymongo.write_concern import WriteConcern
@@ -9,6 +9,12 @@ from unittest.mock import patch
 
 from tests.utils import SingleCollectionTest
 from txmongo.protocol import Reply
+
+try:
+    from pymongo.errors import NotPrimaryError
+except ImportError:
+    # For pymongo < 3.12
+    from pymongo.errors import NotMasterError as NotPrimaryError
 
 
 class TestArgsValidation(SingleCollectionTest):
@@ -242,4 +248,4 @@ class TestOperationFailure(SingleCollectionTest):
         with patch('txmongo.protocol.MongoProtocol.send_QUERY', side_effect=fake_send_query):
             yield self.assertFailure(
                     self.coll.bulk_write([UpdateOne({}, {'$set': {'x': 42}}, upsert=True)], ordered=True),
-                    OperationFailure, NotMasterError)
+                    OperationFailure, NotPrimaryError)

--- a/tests/basic/test_write_concern.py
+++ b/tests/basic/test_write_concern.py
@@ -137,7 +137,7 @@ class TestWriteConcern(unittest.TestCase):
 
     @defer.inlineCallbacks
     def test_ConnectionUrlParams(self):
-        conn = ConnectionPool("mongodb://{0}:{1}/?w=2&j=true".format(mongo_host, mongo_port))
+        conn = ConnectionPool("mongodb://{0}:{1}/?w=2&journal=true".format(mongo_host, mongo_port))
         coll = conn.mydb.mycol
 
         try:

--- a/txmongo/connection.py
+++ b/txmongo/connection.py
@@ -4,12 +4,13 @@
 
 from bson.codec_options import DEFAULT_CODEC_OPTIONS
 from pymongo.errors import AutoReconnect, ConfigurationError, OperationFailure
-from pymongo.uri_parser import parse_uri
 from pymongo.read_preferences import ReadPreference
+from pymongo.uri_parser import parse_uri
 from pymongo.write_concern import WriteConcern
 from twisted.internet import defer, reactor, task
 from twisted.internet.protocol import ReconnectingClientFactory, ClientFactory
 from twisted.python import log
+
 from txmongo.database import Database
 from txmongo.protocol import MongoProtocol, Query
 from txmongo.utils import timeout, get_err

--- a/txmongo/database.py
+++ b/txmongo/database.py
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 from bson.son import SON
-from bson.codec_options import DEFAULT_CODEC_OPTIONS
+
 from txmongo.collection import Collection
 from txmongo.pymongo_internals import _check_command_response
 from txmongo.utils import timeout
@@ -53,10 +53,12 @@ class Database:
 
     @timeout
     def command(self, command, value=1, check=True, allowable_errors=None,
-                codec_options=DEFAULT_CODEC_OPTIONS, _deadline=None, **kwargs):
-        """command(command, value=1, check=True, allowable_errors=None, codec_options=DEFAULT_CODEC_OPTIONS)"""
+                codec_options=None, _deadline=None, **kwargs):
+        """command(command, value=1, check=True, allowable_errors=None, codec_options=None)"""
         if isinstance(command, (bytes, str)):
             command = SON([(command, value)])
+        if codec_options is None:
+            codec_options = self.__codec_options
         options = kwargs.copy()
         command.update(options)
 


### PR DESCRIPTION
PyMongo 4 has a couple of incompatibilities that should be fixed on our side:
* `NotMasterError` renamed to `NotPrimaryError`
* Default CodecOptions now has `UuidRepresentation.UNSPECIFIED`. This highlighted several places in TxMongo where `codec_options` were not properly propagated from `Connection` down to `Database` and `Collection`.
* `bson` package doesn't have `PY3` symbol anymore
* `_UOP` internal symbol removed

UPD: PyMongo 4.9 released yesterday changed some it's internals, so limiting to 4.8 for now.