### PR TITLE
Bump Twisted version to 21.7.0

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -12,7 +12,7 @@ Features
 API Changes
 ^^^^^^^^^^^
 
-- TxMongo now requires Python 3.8+, PyMongo 3.12+ and MongoDB 4.0+.
+- TxMongo now requires Python 3.8+, Twisted 21.7+, PyMongo 3.12+ and MongoDB 4.0+.
 - Some deprecated API methods have been removed:
   - Collection methods `insert()`, `update()` and `remove()`
   - Collection methods `save()`, `find_and_modify()` and `group()`

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url="https://github.com/twisted/txmongo",
     keywords=["mongo", "mongodb", "pymongo", "gridfs", "txmongo"],
     packages=["txmongo", "txmongo._gridfs"],
-    install_requires=["twisted>=14.0", "pymongo>=3.12, <=4.10.1"],
+    install_requires=["twisted>=21.7.0", "pymongo>=3.12, <=4.10.1"],
     extras_require={
         "srv": ["pymongo[srv]>=3.12"],
     },

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{3.8,3.10,3.11,3.12}-{tw247,tw243,tw2310}-{pymongo4101,pymongo480,pymongo3123}-{basic,advanced},
+    py{3.8,3.10,3.11,3.12}-{tw247,tw243,tw2170}-{pymongo4101,pymongo480,pymongo3123}-{basic,advanced},
     pyflakes, manifest
 allowlist_externals=*
 minversion=3.24.1
@@ -18,7 +18,7 @@ deps =
     service_identity
     tw247: Twisted==24.7.0
     tw243: Twisted==24.3.0
-    tw2310: Twisted==23.10.0
+    tw2170: Twisted==21.7.0
     pymongo3123: pymongo==3.12.3
     pymongo480: pymongo==4.8.0
     pymongo4101: pymongo==4.10.1


### PR DESCRIPTION
We have used `Deferred[T]` syntax in txmongo that is only available in Twisted ≥ 21.7.0.

Since this is pretty old version, I suggest to bump the minimum version.