### PR TITLE
Builder pattern methods on Cursor

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -22,6 +22,10 @@ API Changes
 - `find()` method now returns `Cursor()` instance that can be used as async generator to
   asynchronously iterate over results. It can still be used as Deferred too, so this change
   is backward-compatible.
+- `Cursor()` options can be by chaining its methods, for example:
+  ::
+    async for doc in collection.find({"size": "L"}).sort({"price": 1}).limit(10).skip(5):
+        print(doc)
 - `find_with_cursor()` is deprecated and will be removed in the next release.
 
 

--- a/tests/basic/test_collection.py
+++ b/tests/basic/test_collection.py
@@ -38,7 +38,7 @@ def cmp(a, b):
     return (a > b) - (a < b)
 
 
-class TestIndexInfo(unittest.TestCase):
+class TestCollectionMethods(unittest.TestCase):
 
     timeout = 5
 
@@ -54,7 +54,7 @@ class TestIndexInfo(unittest.TestCase):
         yield self.conn.disconnect()
 
     @defer.inlineCallbacks
-    def test_collection(self):
+    def test_type_checking(self):
         self.assertRaises(TypeError, Collection, self.db, 5)
 
         def make_col(base, name):
@@ -76,6 +76,7 @@ class TestIndexInfo(unittest.TestCase):
         self.assertRaises(TypeError, self.db.test.find, projection="test")
         self.assertRaises(TypeError, self.db.test.find, skip="test")
         self.assertRaises(TypeError, self.db.test.find, limit="test")
+        self.assertRaises(TypeError, self.db.test.find, batch_size="test")
         self.assertRaises(TypeError, self.db.test.find, sort="test")
         self.assertRaises(TypeError, self.db.test.find, skip="test")
         self.assertRaises(TypeError, self.db.test.insert_many, [1])

--- a/txmongo/protocol.py
+++ b/txmongo/protocol.py
@@ -13,6 +13,8 @@ implementation can be shared. This includes BSON encoding and
 decoding as well as Exception types, when applicable.
 """
 
+from __future__ import annotations
+
 import base64
 import hashlib
 import hmac
@@ -117,7 +119,7 @@ class BaseMessage:
     @abstractmethod
     def decode(
         cls, request_id: int, response_to: int, opcode: int, message_data: bytes
-    ) -> "BaseMessage": ...
+    ) -> BaseMessage: ...
 
 
 QUERY_TAILABLE_CURSOR = 1 << 1
@@ -155,7 +157,7 @@ class Query(BaseMessage):
     @classmethod
     def decode(
         cls, request_id: int, response_to: int, opcode: int, message_data: bytes
-    ) -> "Query":
+    ) -> Query:
         (flags,) = struct.unpack("<i", message_data[16:20])
         name = message_data[20:].split(b"\x00", 1)[0]
         offset = 20 + len(name) + 1
@@ -214,7 +216,7 @@ class Reply(BaseMessage):
     @classmethod
     def decode(
         cls, request_id: int, response_to: int, opcode: int, message_data: bytes
-    ) -> "Reply":
+    ) -> Reply:
         msg_len = len(message_data)
         (response_flags, cursor_id, starting_from, n_returned) = struct.unpack(
             "<iqii", message_data[16:36]
@@ -268,7 +270,7 @@ class Msg(BaseMessage):
         acknowledged: bool = True,
         request_id: int = 0,
         response_to: int = 0,
-    ) -> "Msg":
+    ) -> Msg:
         encoded_payload = {}
         if payload:
             encoded_payload = {
@@ -330,7 +332,7 @@ class Msg(BaseMessage):
     @classmethod
     def decode(
         cls, request_id: int, response_to: int, opcode: int, message_data: bytes
-    ) -> "Msg":
+    ) -> Msg:
         msg_length = len(message_data)
         body = None
         payload: Dict[str, List[bytes]] = {}


### PR DESCRIPTION
Add builder-pattern methods for Cursor allowing doing queries like this:

```python
async for doc in collection.find({"size": "L"}).sort({"price": 1}).skip(10).limit(50):
    print(doc)
```

