### PR TITLE
Split count() into count_documents() and estimated_document_count()

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -19,6 +19,8 @@ Features
   - Limitations:
     - No session options are supported for `start_session()` yet
     - Only `write_concern` and `max_commit_time_ms` options are supported for `start_transaction()`
+- `Collection.count()` method is deprecated
+  - Please use new `Collection.count_documents()` and `Collection.estimated_document_count()` methods.
 
 API Changes
 ^^^^^^^^^^^

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -19,13 +19,13 @@ Features
   - Limitations:
     - No session options are supported for `start_session()` yet
     - Only `write_concern` and `max_commit_time_ms` options are supported for `start_transaction()`
-- `Collection.count()` method is deprecated
-  - Please use new `Collection.count_documents()` and `Collection.estimated_document_count()` methods.
 
 API Changes
 ^^^^^^^^^^^
 
 - find_one_and_* methods now returns None if called with unacknowledged write_concern.
+- `Collection.count()` method is deprecated
+  - Please use new `Collection.count_documents()` and `Collection.estimated_document_count()` methods.
 
 Release 24.1.0 (2024-11-13)
 ---------------------------

--- a/tests/advanced/test_auth.py
+++ b/tests/advanced/test_auth.py
@@ -133,7 +133,7 @@ class TestMongoAuth(unittest.TestCase, MongoAuth):
 
             yield defer.gatherResults([coll.insert_one({"x": 42}) for _ in range(n)])
 
-            cnt = yield coll.count()
+            cnt = yield coll.count_documents({})
             self.assertEqual(cnt, n)
         finally:
             yield conn.disconnect()
@@ -155,7 +155,7 @@ class TestMongoAuth(unittest.TestCase, MongoAuth):
         try:
             yield defer.gatherResults([coll.insert_one({"x": 42}) for _ in range(n)])
 
-            cnt = yield coll.count()
+            cnt = yield coll.count_documents({})
             self.assertEqual(cnt, n)
         finally:
             yield conn.disconnect()
@@ -555,7 +555,7 @@ SJob7FjDAWWJeLCfsmu6Vy2OVg==
                 self.client_subject, "", mechanism="MONGODB-X509"
             )
             yield conn.db.coll.insert_one({"x": 42})
-            cnt = yield conn.db.coll.count()
+            cnt = yield conn.db.coll.count_documents({})
             self.assertEqual(cnt, 1)
         finally:
             yield conn.disconnect()

--- a/tests/advanced/test_replicaset.py
+++ b/tests/advanced/test_replicaset.py
@@ -333,15 +333,15 @@ class TestReplicaSet(unittest.TestCase):
             ping_timeout=5,
         )
         try:
-            yield conn.db.coll.count()
+            yield conn.db.coll.count_documents({})
             # check that 5s pingers won't break connection if it is healthy
             yield self.__sleep(6)
-            yield conn.db.coll.count()
+            yield conn.db.coll.count_documents({})
             yield self.__mongod[0].kill(signal.SIGSTOP)
             yield self.__sleep(0.2)
             while True:
                 try:
-                    yield conn.db.coll.count()
+                    yield conn.db.coll.count_documents({})
                     break
                 except AutoReconnect:
                     pass

--- a/tests/basic/test_bulk.py
+++ b/tests/basic/test_bulk.py
@@ -18,7 +18,7 @@ class TestArgsValidation(SingleCollectionTest):
     def test_Generator(self):
         # bulk_write should accept comprehensions because they're cool
         yield self.coll.bulk_write(InsertOne({"x": i}) for i in range(10))
-        self.assertEqual((yield self.coll.count()), 10)
+        self.assertEqual((yield self.coll.count_documents({})), 10)
 
     def test_Types(self):
         # requests argument must be iterable of _WriteOps
@@ -39,7 +39,7 @@ class TestErrorHandling(SingleCollectionTest):
             [InsertOne({"_id": 2}), InsertOne({"_id": 1}), InsertOne({"_id": 3})]
         )
         yield self.assertFailure(result, BulkWriteError)
-        self.assertEqual((yield self.coll.count()), 2)
+        self.assertEqual((yield self.coll.count_documents({})), 2)
 
     @defer.inlineCallbacks
     def test_Insert_Unordered_Ack(self):
@@ -49,7 +49,7 @@ class TestErrorHandling(SingleCollectionTest):
         )
 
         yield self.assertFailure(result, BulkWriteError)
-        self.assertEqual((yield self.coll.count()), 3)
+        self.assertEqual((yield self.coll.count_documents({})), 3)
 
     @defer.inlineCallbacks
     def test_Insert_Ordered_Unack(self):
@@ -57,7 +57,7 @@ class TestErrorHandling(SingleCollectionTest):
         yield w0.bulk_write(
             [InsertOne({"_id": 2}), InsertOne({"_id": 1}), InsertOne({"_id": 3})]
         )
-        self.assertEqual((yield self.coll.count()), 2)
+        self.assertEqual((yield self.coll.count_documents({})), 2)
 
     @defer.inlineCallbacks
     def test_Insert_Unordered_Unack(self):
@@ -66,7 +66,7 @@ class TestErrorHandling(SingleCollectionTest):
             [InsertOne({"_id": 2}), InsertOne({"_id": 1}), InsertOne({"_id": 3})],
             ordered=False,
         )
-        self.assertEqual((yield self.coll.count()), 3)
+        self.assertEqual((yield self.coll.count_documents({})), 3)
 
     @defer.inlineCallbacks
     def test_Mixed_Ordered_Ack(self):
@@ -147,7 +147,7 @@ class TestBulkInsert(SingleCollectionTest):
         result = yield self.coll.bulk_write(
             [InsertOne({"x": 42}), InsertOne({"y": 123})]
         )
-        self.assertEqual((yield self.coll.count()), 2)
+        self.assertEqual((yield self.coll.count_documents({})), 2)
         self.assertIsInstance(result, BulkWriteResult)
         self.assertEqual(result.inserted_count, 2)
 
@@ -237,7 +237,7 @@ class TestBulkDelete(SingleCollectionTest):
         result = yield self.coll.bulk_write(
             [DeleteOne({"x": 42}), DeleteOne({"x": {"$gt": 100}})]
         )
-        self.assertEqual((yield self.coll.count()), 1)
+        self.assertEqual((yield self.coll.count_documents({})), 1)
 
         self.assertIsInstance(result, BulkWriteResult)
         self.assertEqual(result.deleted_count, 2)
@@ -248,13 +248,13 @@ class TestHuge(SingleCollectionTest):
     @defer.inlineCallbacks
     def test_MoreThan1k(self):
         yield self.coll.bulk_write(InsertOne({"_id": i}) for i in range(2016))
-        self.assertEqual((yield self.coll.count()), 2016)
+        self.assertEqual((yield self.coll.count_documents({})), 2016)
 
     @defer.inlineCallbacks
     def test_MoreThan16Mb(self):
         str_8mb = "y" * 8388608
         yield self.coll.bulk_write(InsertOne({"x": str_8mb}) for _ in range(5))
-        self.assertEqual((yield self.coll.count()), 5)
+        self.assertEqual((yield self.coll.count_documents({})), 5)
 
         docs = yield self.coll.find()
         total_size = sum(len(bson.encode(doc)) for doc in docs)

--- a/tests/basic/test_cancel.py
+++ b/tests/basic/test_cancel.py
@@ -149,7 +149,7 @@ class TestCancelIntegrated(unittest.TestCase):
         # If ConnectionPool picks already active connection, the query is sent
         # to MongoDB immediately and there is no way to cancel it
 
-        yield self.coll.count()
+        yield self.coll.count_documents({})
 
         d = self.coll.insert_one({"x": 42})
         d.cancel()
@@ -158,5 +158,5 @@ class TestCancelIntegrated(unittest.TestCase):
 
         self.failureResultOf(d, defer.CancelledError)
 
-        cnt = yield self.coll.count()
+        cnt = yield self.coll.count_documents({})
         self.assertEqual(cnt, 1)

--- a/tests/basic/test_collection.py
+++ b/tests/basic/test_collection.py
@@ -427,7 +427,7 @@ class TestUuid(unittest.TestCase):
         self.assertEqual(doc["task_id"], new)
 
         yield self.coll.delete_one({"task_id": new})
-        cnt = yield self.coll.count()
+        cnt = yield self.coll.count_documents({})
         self.assertEqual(cnt, 0)
 
     @defer.inlineCallbacks

--- a/tests/basic/test_connection.py
+++ b/tests/basic/test_connection.py
@@ -104,7 +104,7 @@ class TestDropDatabase(unittest.TestCase):
 
     @defer.inlineCallbacks
     def assert_coll_count(self, n):
-        self.assertEqual((yield self.coll.count()), n)
+        self.assertEqual((yield self.coll.count_documents({})), n)
 
     @defer.inlineCallbacks
     def test_by_name(self):

--- a/tests/basic/test_filters.py
+++ b/tests/basic/test_filters.py
@@ -49,7 +49,7 @@ class TestMongoFilters(unittest.TestCase):
         await self.db.command("profile", 0)
 
         profile_filter = {"command." + optionname: optionvalue}
-        cnt = await self.db.system.profile.count(profile_filter)
+        cnt = await self.db.system.profile.count_documents(profile_filter)
         await self.db.system.profile.drop()
         self.assertEqual(cnt, 1)
 
@@ -155,7 +155,7 @@ class TestMongoFilters(unittest.TestCase):
         yield self.db.command("profile", 0)
 
         profile_filter = {"command.sort.x": 1, "command.comment": comment}
-        cnt = yield self.db.system.profile.count(profile_filter)
+        cnt = yield self.db.system.profile.count_documents(profile_filter)
         self.assertEqual(cnt, 1)
 
     def test_Repr(self):

--- a/tests/basic/test_queries.py
+++ b/tests/basic/test_queries.py
@@ -1341,7 +1341,13 @@ class TestEstimateDocumentCount(SingleCollectionTest):
         cmds = await self.db.system.profile.find({"command.count": self.coll.name})
         self.assertEqual(len(cmds), 1)
         cmd = cmds[0]
-        self.assertEqual(cmd["planSummary"], "RECORD_STORE_FAST_COUNT")
+        self.assertIn(
+            cmd["planSummary"],
+            {
+                "RECORD_STORE_FAST_COUNT",
+                "COUNT",  # for MongoDB 4.0
+            },
+        )
 
     async def test_non_existing_collection(self):
         cnt = await self.db.non_existing_coll.estimated_document_count()

--- a/tests/basic/test_sessions.py
+++ b/tests/basic/test_sessions.py
@@ -61,6 +61,7 @@ class TestClientSessions(SingleCollectionTest):
         lambda coll, session: coll.find({}, session=session),
         lambda coll, session: coll.find_one({}, session=session),
         lambda coll, session: iterate_find_with_cursor(coll, session),
+        lambda coll, session: coll.count_documents({}, session=session),
     ]
 
     coll_writes = [

--- a/txmongo/_gridfs/__init__.py
+++ b/txmongo/_gridfs/__init__.py
@@ -192,7 +192,7 @@ class GridFS(object):
         :Parameters:
           - `filename`: ``"filename"`` of the file to get version count of
         """
-        return self.__files.count({"filename": filename})
+        return self.__files.count_documents({"filename": filename})
 
     def get_last_version(self, filename):
         """Get a file from GridFS by ``"filename"``.

--- a/txmongo/_gridfs/grid_file.py
+++ b/txmongo/_gridfs/grid_file.py
@@ -194,7 +194,7 @@ class GridIn:
         def on_md5(md5):
             self._file["md5"] = md5
             self._file["length"] = self._position
-            self._file["uploadDate"] = datetime.datetime.utcnow()
+            self._file["uploadDate"] = datetime.datetime.now(datetime.UTC)
             return self._coll.files.insert_one(self._file)
 
         return (

--- a/txmongo/_gridfs/grid_file.py
+++ b/txmongo/_gridfs/grid_file.py
@@ -194,7 +194,7 @@ class GridIn:
         def on_md5(md5):
             self._file["md5"] = md5
             self._file["length"] = self._position
-            self._file["uploadDate"] = datetime.datetime.now(datetime.UTC)
+            self._file["uploadDate"] = datetime.datetime.now(datetime.timezone.utc)
             return self._coll.files.insert_one(self._file)
 
         return (

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -1550,7 +1550,25 @@ class Collection:
         session: ClientSession = None,
         _deadline=None,
     ):
-        """aggregate(pipeline, full_response=False, *, comment: str = None, max_time_ms: int = None, hint: txmongo.filters.hint = None, session: ClientSession=None)"""
+        """aggregate(pipeline, full_response=False, *, comment: str = None, max_time_ms: int = None, hint: txmongo.filters.hint = None, session: ClientSession=None)
+
+        Perform an aggregation using the aggregation framework on this collection.
+
+        :param pipeline:
+            a list of aggregation pipeline stages.
+        :param full_response:
+            if True, the result will include the full response from the server.
+        :param initial_batch_size:
+            the number of documents to return in the first batch.
+        :param comment:
+            a string to attach to the command for debugging purposes.
+        :param max_time_ms:
+            the maximum amount of time (ms) to allow the operation to run.
+        :param hint:
+            an index to use for the aggregation. Must be a :class:`txmongo.filter.hint` instance.
+        :param session:
+            Optional :class:`~txmongo.sessions.ClientSession` to use for this operation.
+        """
 
         def on_ok(raw, data=None):
             if data is None:


### PR DESCRIPTION
- [x] Implement estimated_document_count()
- [x] Implement count_documents()
- [x] Update NEWS.rst
- [x] Update docs for `Collection.aggregate()`
- [x] Update examples
- [x] Fix tests to use count_documents() instead of count()
