### PR TITLE
Bump minimum Twisted version to 22.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 
 
 env:
-    - TOX_ENV=tw217
+    - TOX_ENV=tw228
     - TOX_ENV=tw2210
     - TOX_ENV=tw2310
     - TOX_ENV=twlatest

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -19,6 +19,7 @@ Features
   - Limitations:
     - No session options are supported for `start_session()` yet
     - Only `write_concern` and `max_commit_time_ms` options are supported for `start_transaction()`
+- Minimum Twisted version is now 22.8.0
 
 API Changes
 ^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     url="https://github.com/twisted/txmongo",
     keywords=["mongo", "mongodb", "pymongo", "gridfs", "txmongo"],
     packages=["txmongo", "txmongo._gridfs"],
-    install_requires=["twisted>=21.7.0", "pymongo>=3.12, <=4.10.1"],
+    install_requires=["twisted>=22.8.0", "pymongo>=3.12, <=4.10.1"],
     extras_require={
         "srv": ["pymongo[srv]>=3.12"],
     },

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{3.8,3.10,3.11,3.12}-{tw247,tw243,tw2170}-{pymongo4101,pymongo480,pymongo3123}-{basic,advanced},
+    py{3.8,3.10,3.11,3.12}-{tw247,tw243,tw228}-{pymongo4101,pymongo480,pymongo3123}-{basic,advanced},
     pyflakes, manifest
 allowlist_externals=*
 minversion=3.24.1
@@ -18,7 +18,7 @@ deps =
     service_identity
     tw247: Twisted==24.7.0
     tw243: Twisted==24.3.0
-    tw2170: Twisted==21.7.0
+    tw228: Twisted==22.8.0
     pymongo3123: pymongo==3.12.3
     pymongo480: pymongo==4.8.0
     pymongo4101: pymongo==4.10.1


### PR DESCRIPTION
It turns out that Twisted prior to v22.8.0 doesn't properly support `async def` test methods — it doesn't catch failed asserts in such methods 😱  But we need a lot of `async with` in transaction tests.

There are possible workarounds for it, but 22.8.0 sounds old enough.