### PR TITLE
Fix compatibility with Twisted 24.10+

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -25,6 +25,11 @@ API Changes
 
 - find_one_and_* methods now returns None if called with unacknowledged write_concern.
 
+Bugfixes
+^^^^^^^^
+
+- Fixed compatibility with Twisted ≥24.10.0
+
 Release 24.1.0 (2024-11-13)
 ---------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Twisted~=24.7.0
+Twisted~=24.11.0
 pymongo>=3.12,<=4.10.1
 setuptools~=71.1.0
 -e .

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{3.8,3.10,3.11,3.12}-{tw247,tw243,tw2170}-{pymongo4101,pymongo480,pymongo3123}-{basic,advanced},
+    py{3.8,3.10,3.11,3.12}-{tw2411,tw243,tw2170}-{pymongo4101,pymongo480,pymongo3123}-{basic,advanced},
     pyflakes, manifest
 allowlist_externals=*
 minversion=3.24.1
@@ -16,7 +16,7 @@ deps =
     pyopenssl
     pyparsing
     service_identity
-    tw247: Twisted==24.7.0
+    tw2411: Twisted==24.11.0
     tw243: Twisted==24.3.0
     tw2170: Twisted==21.7.0
     pymongo3123: pymongo==3.12.3

--- a/txmongo/collection.py
+++ b/txmongo/collection.py
@@ -91,21 +91,22 @@ def _apply_find_filter(spec, c_filter):
 
 _DEFERRED_METHODS = frozenset(
     {
+        "addBoth",
         "addCallback",
         "addCallbacks",
         "addErrback",
-        "addBoth",
-        "called",
-        "paused",
         "addTimeout",
-        "chainDeferred",
+        "asFuture",
         "callback",
+        "called",
+        "cancel",
+        "chainDeferred",
         "errback",
         "pause",
-        "unpause",
-        "cancel",
+        "paused",
+        "result",
         "send",
-        "asFuture",
+        "unpause",
     }
 )
 


### PR DESCRIPTION
Current version of TxMongo is broken when used with Twisted ≥24.10.0 because we forgot to add `"result"` to `_DEFERRED_METHODS` :(

Code to reproduce:

```python
@react
async def main(reactor):
    conn = ConnectionPool()
    db = conn.db
    coll = db.coll

    await coll.drop()
    await coll.insert_one({"x": 1})

    print(await coll.find())

    await conn.disconnect()
```

This example hangs hardly on `await coll.find()`