### PR TITLE
Update runner to Ubuntu 22.04 for tests

### DIFF
--- a/.github/workflows/tests-all-versions.yml
+++ b/.github/workflows/tests-all-versions.yml
@@ -54,7 +54,7 @@ jobs:
         run: tox -f py${{ matrix.python-version }} advanced
 
   advanced_old_mongo:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.8', '3.11', '3.12']

--- a/.github/workflows/tests-all-versions.yml
+++ b/.github/workflows/tests-all-versions.yml
@@ -31,7 +31,7 @@ jobs:
           path: htmlcov
 
   advanced:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.8', '3.11', '3.12']

--- a/.github/workflows/tests-on-push.yml
+++ b/.github/workflows/tests-on-push.yml
@@ -30,7 +30,7 @@ jobs:
           path: htmlcov
 
   advanced:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.8']
@@ -53,7 +53,7 @@ jobs:
         run: tox -f py${{ matrix.python-version }} advanced
 
   advanced_old_mongo:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.8']


### PR DESCRIPTION
The original tests hung waiting for 20.04 images, they were removed.